### PR TITLE
[Feat] 공정 계획 페이지 api 연동

### DIFF
--- a/src/api/tradeProcess.js
+++ b/src/api/tradeProcess.js
@@ -1,0 +1,29 @@
+import api from './index.js'
+
+const PATH = '/trade-process'
+
+const toTradeProcessPlan = (dto) => ({
+  id: `tp-${dto.idx}`,
+  tradeProcessId: dto.idx,
+  masterScheduleId: dto.masterScheduleId,
+  projectId: dto.projectId,
+
+  name: dto.processName,
+  trade: dto.tradeName,
+  partner: dto.partnerCompany || '',
+
+  start: dto.plannedStart,
+  end: dto.plannedEnd,
+
+  weightPct: dto.weightPct ?? 0,
+  isMilestone: dto.isMilestone ?? false,
+
+  planType: '기준',
+  status: '진행 예정',
+  source: 'trade_process',
+})
+
+export const fetchTradeProcessList = async (params = {}) => {
+  const dtos = await api.get(PATH, { params })
+  return Array.isArray(dtos) ? dtos.map(toTradeProcessPlan) : []
+}

--- a/src/api/workplan.js
+++ b/src/api/workplan.js
@@ -4,11 +4,9 @@ const PATH = '/work-plan'
 
 const normalizeStatus = (status) => {
   if (!status) return '진행 예정'
-
   if (status === '계획') return '진행 예정'
   if (status === '검토 중') return '진행 예정'
   if (status === '확정') return '진행 예정'
-
   return status
 }
 
@@ -29,6 +27,13 @@ const toPlan = (dto) => {
 
   return {
     id: dto.idx,
+    tradeProcessId: dto.tradeProcessId ?? dto.trade_process_id ?? dto.tradeProcess?.idx ?? null,
+
+    tradeProcessName: dto.tradeProcessName ?? dto.trade_process_name ?? null,
+    parentWorkPlanId:
+      dto.parentWorkPlanId ?? dto.parent_work_plan_id ?? dto.parentWorkPlan?.idx ?? null,
+
+    parentWorkPlanName: dto.parentWorkPlanName ?? dto.parent_work_plan_name ?? null,
     name: dto.name,
     trade: dto.trade,
     location: dto.location,
@@ -37,6 +42,9 @@ const toPlan = (dto) => {
     start: dto.startDate,
     end: dto.endDate,
     actualStart: dto.actualStart || null,
+    actualPct: dto.actualPct ?? dto.actualProgress ?? null,
+    progressPct: dto.progressPct ?? dto.progress ?? null,
+    processProgress: dto.processProgress ?? null,
     requiredCount: dto.requiredCount ?? 0,
     workers: normalizeStringList(dto.workers),
     equipment: normalizeStringList(dto.equipment),
@@ -58,11 +66,14 @@ const toPlan = (dto) => {
 
 /**
  * 프론트 plan 객체 → 백엔드 Req
- * (plan 등록/수정 시 사용)
  */
 const toReq = (plan) => ({
+  // ── 1단계 추가 ────────────────────────────────────────────────────────────
+  tradeProcessId: plan.tradeProcessId || null,
+  // ──────────────────────────────────────────────────────────────────────────
   name: plan.name,
   trade: plan.trade,
+  parentWorkPlanId: plan.parentWorkPlanId || null,
   location: plan.location,
   planType: plan.planType,
   status: normalizeStatus(plan.status),
@@ -77,10 +88,6 @@ const toReq = (plan) => ({
   workers: Array.isArray(plan.workers) ? plan.workers : [],
   equipment: Array.isArray(plan.equipment) ? plan.equipment : [],
 })
-
-// =========================================================
-// API 함수들
-// =========================================================
 
 /**
  * 작업 계획 등록

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -42,6 +42,8 @@ export const useAuthStore = defineStore('auth', () => {
       accessScope.value = ACCESS_FULL
       role.value = ROLE_SITE_MANAGER
       isAuthenticated.value = true
+      isUpload.value = false
+      persistAuth()
       return true
     }
     if (id === 'viewer' && pw === 'viewer') {
@@ -49,7 +51,8 @@ export const useAuthStore = defineStore('auth', () => {
       accessScope.value = ACCESS_SITE_DASHBOARD_ONLY
       role.value = ROLE_SITE_MANAGER
       isAuthenticated.value = true
-      isUpload.value = true
+      isUpload.value = false
+      persistAuth()
       return true
     }
     return false

--- a/src/views/schedule/WorkPlanView.vue
+++ b/src/views/schedule/WorkPlanView.vue
@@ -20,11 +20,15 @@ import {
   Save,
 } from 'lucide-vue-next'
 import { planStore } from '@/data/planStore'
-import { fetchWorkPlanList, submitWeeklyWorkPlan } from '@/api/workplan.js'
+import { fetchTradeProcessList } from '@/api/tradeProcess.js'
+import { fetchWorkPlanList, submitWeeklyWorkPlan, createWorkPlan } from '@/api/workplan.js'
+
+const selectedProjectId = ref(1)
 
 const weeklyPlans = ref([]) // 주간 작업 계획
 const monthlyPlans = ref([]) // 월간 작업 계획
 const annualPlans = ref([]) // 연간 작업 계획
+const baselinePlans = ref([]) // 최초 공정표 기반 기준 공정
 const loading = ref(false)
 const viewMode = ref('weekly')
 const filterTrade = ref('')
@@ -380,13 +384,45 @@ function fixVerifyRow(row) {
 function removeVerifyRow(row) {
   verifyRows.value = verifyRows.value.filter((r) => r.id !== row.id)
 }
-function confirmVerifyAndApply() {
-  // TODO: 백엔드 일괄 저장 API 연동 예정
-  //   await createWorkPlanBulk({ planType: verifyCategory.value, rows: verifyRows.value })
-  //   await loadPlans()
-  // 현재는 데모로 알림만 표시 (파일 파싱 + 일괄 저장 API는 추후 구현)
-  showVerifyModal.value = false
-  alert(`${verifyCategory.value} 계획서 ${verifyRows.value.length}건이 간트차트에 반영되었습니다.`)
+async function confirmVerifyAndApply() {
+  const validRows = verifyRows.value.filter((row) => row.name && row.trade && row.start && row.end)
+
+  if (!validRows.length) {
+    alert('저장할 수 있는 작업이 없습니다.')
+    return
+  }
+
+  try {
+    await Promise.all(
+      validRows.map((row) =>
+        createWorkPlan({
+          name: row.name,
+          trade: row.trade,
+          location: row.location,
+          planType: verifyCategory.value, // '연간' 또는 '월간'
+          status: '진행 예정',
+          start: row.start,
+          end: row.end,
+          requiredCount: 0,
+          workers: [],
+          equipment: [],
+          partner: '',
+          manager: '',
+          contact: '',
+          weekStart: '',
+          note: '',
+        }),
+      ),
+    )
+
+    showVerifyModal.value = false
+    alert(`${verifyCategory.value} 계획서 ${validRows.length}건이 저장되었습니다.`)
+
+    await loadPlans()
+  } catch (err) {
+    console.error(`${verifyCategory.value} 계획서 저장 실패:`, err)
+    alert(err.message || '계획서 저장에 실패했습니다.')
+  }
 }
 function cancelVerify() {
   showVerifyModal.value = false
@@ -446,31 +482,84 @@ const EQUIPMENT_GROUPS = [
 const showWeeklyForm = ref(false)
 const weeklyForm = ref(null) // { partner, manager, weekStart, items: [...] }
 
+const monthlyPlanOptions = computed(() => {
+  return monthlyPlans.value.map((p) => ({
+    id: p.id,
+    label: `${p.name} / ${p.location || '-'} / ${p.start} ~ ${p.end}`,
+    raw: p,
+  }))
+})
+
 function openWeeklyForm() {
   // 이번 주 시작일(일요일 기준)
   const t = new Date()
   const ws = new Date(t)
   ws.setDate(t.getDate() - t.getDay())
+
+  const weekStart = ws.toISOString().slice(0, 10)
+
   weeklyForm.value = {
+    // 선택한 월간 계획 정보
+    monthlyPlanId: null,
+    monthlyPlanName: '',
+    tradeProcessId: null,
+    trade: '',
+    monthlyStart: '',
+    monthlyEnd: '',
+    monthlyLocation: '',
+
+    // 주간 계획서 공통 정보
     partner: '',
     manager: '',
     contact: '',
-    weekStart: ws.toISOString().slice(0, 10),
-    items: [makeWeeklyItem(ws.toISOString().slice(0, 10))],
+    weekStart,
+
+    // 일자별 작업
+    items: [makeWeeklyItem(weekStart)],
   }
+
   showWeeklyForm.value = true
 }
 
-function makeWeeklyItem(date) {
+function makeWeeklyItem(date, defaults = {}) {
   return {
     id: `wi_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
     date,
-    processName: '', // 공정명 (필수)
-    zone: '', // 작업구역 (필수)
-    workers: [makeWorkerEntry()], // 인력 (필수) - [{ tradeId, trade, count }]
-    equipment: [makeEquipmentEntry()], // 장비 (필수) - [{ equipId, type, count }]
+    processName: defaults.processName || '',
+    zone: defaults.zone || '',
+    workers: [makeWorkerEntry()],
+    equipment: [makeEquipmentEntry()],
     note: '',
   }
+}
+function onSelectMonthlyPlan() {
+  if (!weeklyForm.value) return
+
+  const selected = monthlyPlans.value.find(
+    (p) => String(p.id) === String(weeklyForm.value.monthlyPlanId),
+  )
+
+  if (!selected) return
+
+  weeklyForm.value.monthlyPlanName = selected.name || ''
+  weeklyForm.value.tradeProcessId = selected.tradeProcessId || null
+  weeklyForm.value.trade = selected.trade || ''
+  weeklyForm.value.monthlyStart = selected.start || ''
+  weeklyForm.value.monthlyEnd = selected.end || ''
+  weeklyForm.value.monthlyLocation = selected.location || ''
+
+  weeklyForm.value.partner = selected.partner || ''
+  weeklyForm.value.manager = selected.manager || ''
+  weeklyForm.value.contact = selected.contact || ''
+
+  weeklyForm.value.weekStart = selected.start || weeklyForm.value.weekStart
+
+  weeklyForm.value.items = [
+    makeWeeklyItem(selected.start || weeklyForm.value.weekStart, {
+      processName: selected.name || '',
+      zone: selected.location || '',
+    }),
+  ]
 }
 
 function makeWorkerEntry() {
@@ -520,8 +609,19 @@ function itemEquipmentTotal(item) {
 }
 
 function addWeeklyItem() {
-  weeklyForm.value.items.push(makeWeeklyItem(weeklyForm.value.weekStart))
+  if (!weeklyForm.value) return
+
+  const lastDate = weeklyForm.value.items.at(-1)?.date
+  const baseDate = lastDate || weeklyForm.value.weekStart
+
+  weeklyForm.value.items.push(
+    makeWeeklyItem(baseDate, {
+      processName: weeklyForm.value.monthlyPlanName,
+      zone: weeklyForm.value.monthlyLocation,
+    }),
+  )
 }
+
 function removeWeeklyItem(idx) {
   if (weeklyForm.value.items.length <= 1) return
   weeklyForm.value.items.splice(idx, 1)
@@ -529,8 +629,12 @@ function removeWeeklyItem(idx) {
 
 const weeklyFormValid = computed(() => {
   if (!weeklyForm.value) return false
+
   const w = weeklyForm.value
+
+  if (!w.monthlyPlanId) return false
   if (!w.partner.trim() || !w.manager.trim()) return false
+
   return w.items.every(
     (it) =>
       it.date &&
@@ -552,15 +656,21 @@ async function submitWeeklyForm() {
   try {
     // 백엔드 WeeklySubmitReq 형식으로 매핑
     const payload = {
+      // 선택한 월간 계획이 주간 계획의 부모가 됨
+      parentWorkPlanId: w.monthlyPlanId,
+
+      // 기준 공정 연결
+      tradeProcessId: w.tradeProcessId,
+
       partner: w.partner,
       manager: w.manager,
       contact: w.contact,
       weekStart: w.weekStart,
+
       items: w.items.map((it) => ({
         date: it.date,
         processName: it.processName,
         zone: it.zone,
-        // tradeId/equipId는 클라이언트 키이므로 제외
         workers: it.workers.map((wk) => ({
           trade: wk.trade,
           count: Number(wk.count) || 0,
@@ -596,30 +706,25 @@ function handleClickOutside(e) {
 
 // 작업 계획 목록 로드 (주간 + 월간 + 연간 동시 호출)
 async function loadPlans() {
-  loading.value = true
   try {
-    const params = {}
-    if (filterTrade.value) params.trade = filterTrade.value
-    const [weeklyRes, monthlyRes, yearlyRes] = await Promise.all([
-      fetchWorkPlanList({ ...params, planType: '주간' }),
-      fetchWorkPlanList({ ...params, planType: '월간' }),
-      fetchWorkPlanList({ ...params, planType: '연간' }),
+    loading.value = true
+
+    const projectId = selectedProjectId.value || 1
+
+    const [baselineRes, weeklyRes, monthlyRes, yearlyRes] = await Promise.all([
+      fetchTradeProcessList({ projectId }),
+      fetchWorkPlanList({ planType: '주간' }),
+      fetchWorkPlanList({ planType: '월간' }),
+      fetchWorkPlanList({ planType: '연간' }),
     ])
 
+    baselinePlans.value = baselineRes
     weeklyPlans.value = weeklyRes
     monthlyPlans.value = monthlyRes
     annualPlans.value = yearlyRes
-
-    // 백엔드에 저장된 연장 정보를 planStore에 동기화
-    const allPlans = [...weeklyRes, ...monthlyRes, ...yearlyRes]
-    allPlans.forEach((p) => {
-      if (p.extension) {
-        planStore.extensions[p.id] = p.extension
-      }
-    })
   } catch (err) {
-    console.error('작업 계획 조회 실패:', err)
-    alert(err.message || '작업 계획을 불러오지 못했습니다.')
+    console.error('계획 목록 조회 실패:', err)
+    alert(err.message || '계획 목록을 불러오지 못했습니다.')
   } finally {
     loading.value = false
   }
@@ -718,9 +823,46 @@ const isCurrentYear = computed(() => {
 })
 
 // 이번 달과 겹치는 작업 (연장된 종료일까지 고려)
+const monthlyGanttSource = computed(() => {
+  let r = [...baselinePlans.value, ...monthlyPlans.value]
+
+  if (filterTrade.value) {
+    r = r.filter((p) => p.trade === filterTrade.value)
+  }
+
+  if (filterStatus.value) {
+    r = r.filter((p) => workPlanStatus(p) === filterStatus.value)
+  }
+
+  return r
+})
+
+const yearlyGanttSource = computed(() => {
+  let r = [...baselinePlans.value, ...annualPlans.value]
+
+  if (filterTrade.value) {
+    r = r.filter((p) => p.trade === filterTrade.value)
+  }
+
+  if (filterStatus.value) {
+    r = r.filter((p) => workPlanStatus(p) === filterStatus.value)
+  }
+
+  return r
+})
+
 const ganttPlans = computed(() => {
   const { firstDate, lastDate } = monthMeta.value
-  return filtered.value.filter((p) => !(effectiveEnd(p) < firstDate || p.start > lastDate))
+
+  return monthlyGanttSource.value.filter(
+    (p) => !(effectiveEnd(p) < firstDate || p.start > lastDate),
+  )
+})
+
+const yearlyPlans = computed(() => {
+  const { firstDate, lastDate } = yearMeta.value
+
+  return yearlyGanttSource.value.filter((p) => !(effectiveEnd(p) < firstDate || p.start > lastDate))
 })
 
 const yearMeta = computed(() => {
@@ -739,11 +881,6 @@ const yearMeta = computed(() => {
   }
 })
 
-const yearlyPlans = computed(() => {
-  const { firstDate, lastDate } = yearMeta.value
-  return annualFiltered.value.filter((p) => !(effectiveEnd(p) < firstDate || p.start > lastDate))
-})
-
 // 막대 위치/너비 계산 — 이번 달 영역 내로 클리핑
 function barStyle(startStr, endStr) {
   if (!startStr || !endStr) return null
@@ -758,6 +895,14 @@ function barStyle(startStr, endStr) {
     left: `${(sd - 1) * GANTT_DAY_W + 4}px`,
     width: `${span * GANTT_DAY_W - 8}px`,
   }
+}
+
+function monthCellCenterStyle(dateStr) {
+  if (!dateStr) return null
+  const { firstDate, lastDate } = monthMeta.value
+  if (dateStr < firstDate || dateStr > lastDate) return null
+  const day = Number(dateStr.slice(8, 10))
+  return { left: `${(day - 1) * GANTT_DAY_W + GANTT_DAY_W / 2}px` }
 }
 
 function yearBarStyle(startStr, endStr) {
@@ -790,9 +935,58 @@ function actualLineRange(p) {
 
 function progressFillEnd(p) {
   const range = actualLineRange(p)
-  const t = new Date().toISOString().slice(0, 10)
+  const t = formatDateLocal(new Date())
   if (t < range.start) return null
   return t > range.end ? range.end : t
+}
+
+function progressPctOf(p) {
+  const raw = p?.raw || p || {}
+  const value =
+    raw.actualPct ??
+    raw.progressPct ??
+    raw.progress ??
+    raw.processProgress ??
+    raw.actualProgress ??
+    p?.actualPct ??
+    p?.progressPct ??
+    p?.progress ??
+    p?.processProgress ??
+    p?.actualProgress
+  const n = Number(value)
+  return Number.isFinite(n) ? Math.max(0, Math.min(100, n)) : null
+}
+
+function progressBarStyle(p, styleFn) {
+  const full = styleFn(p.start, p.end)
+  if (!full) return { width: '0px' }
+
+  const pct = progressPctOf(p)
+  if (pct != null) return { width: `${pct}%` }
+
+  const fillEnd = progressFillEnd(p)
+  if (!fillEnd) return { width: '0px' }
+
+  const fill = styleFn(p.start, fillEnd)
+  if (!fill) return { width: '0px' }
+
+  const fullLeft = parseFloat(full.left)
+  const fullWidth = parseFloat(full.width)
+  const fillLeft = parseFloat(fill.left)
+  const fillWidth = parseFloat(fill.width)
+  const width = Math.max(0, Math.min(fullWidth, fillLeft + fillWidth - fullLeft))
+
+  return { width: `${width}px` }
+}
+
+function progressDotStyle(p, styleFn) {
+  const widthValue = progressBarStyle(p, styleFn).width
+  const width = widthValue.endsWith('%')
+    ? (parseFloat(widthValue) / 100) * parseFloat(styleFn(p.start, p.end)?.width || 0)
+    : parseFloat(widthValue)
+
+  if (!Number.isFinite(width) || width <= 0) return { display: 'none' }
+  return { left: `${Math.max(0, width - 4)}px` }
 }
 
 // 오늘 라인
@@ -813,6 +1007,395 @@ const extensionCount = computed(() => Object.keys(planStore.extensions).length)
 function selectViewMode(mode) {
   viewMode.value = mode
   selectedPlan.value = null
+}
+
+// =========================
+// 공종 → 공정 → 위치별 실행계획 (3단 그룹핑)
+// =========================
+// trade_process / work_plan 양쪽 응답 형태가 다양할 수 있어
+// 가능한 필드명을 모두 폴백으로 처리한다.
+function baseId(b) {
+  return b.tradeProcessId ?? b.idx ?? b.id ?? null
+}
+function baseTradeName(b) {
+  return b.tradeName ?? b.trade ?? '미분류'
+}
+function baseProcessName(b) {
+  return b.processName ?? b.name ?? '(공정명 없음)'
+}
+function baseStart(b) {
+  return b.plannedStart ?? b.baselineStart ?? b.start ?? null
+}
+function baseEnd(b) {
+  return b.plannedEnd ?? b.baselineEnd ?? b.end ?? null
+}
+function baseWeight(b) {
+  return b.weightPct ?? b.weight ?? null
+}
+function baseIsMilestone(b) {
+  return b.isMilestone ?? b.milestone ?? false
+}
+function workPlanTradeProcessId(w) {
+  return w.tradeProcessId ?? w.trade_process_id ?? w.baseId ?? null
+}
+
+// 공종 그룹핑 공통 함수
+// plans: work_plan 목록 (annual 또는 monthly)
+// returns: [{ group, items: [{ ...baseline, workPlans: [...] }] }]
+function buildGroups(plans) {
+  // 공종 → 공정 맵 구성 (baselinePlans 기준)
+  const tradeMap = new Map()
+
+  for (const b of baselinePlans.value) {
+    if (filterTrade.value && baseTradeName(b) !== filterTrade.value) continue
+
+    const trade = baseTradeName(b)
+    if (!tradeMap.has(trade)) tradeMap.set(trade, [])
+    tradeMap.get(trade).push({
+      id: baseId(b),
+      tradeProcessId: baseId(b),
+      name: baseProcessName(b),
+      trade,
+      weightPct: baseWeight(b),
+      baselineStart: baseStart(b),
+      baselineEnd: baseEnd(b),
+      isMilestone: baseIsMilestone(b),
+      raw: b,
+      workPlans: [],
+    })
+  }
+
+  // 미연결 work_plan 보관용
+  const orphans = []
+
+  // work_plan들을 해당 trade_process에 매칭
+  for (const w of plans) {
+    const tpid = workPlanTradeProcessId(w)
+    if (tpid == null) {
+      console.warn('[WorkPlanView] tradeProcessId 없는 work_plan:', w)
+      orphans.push(w)
+      continue
+    }
+
+    let matched = null
+    for (const arr of tradeMap.values()) {
+      const found = arr.find((it) => String(it.tradeProcessId) === String(tpid))
+      if (found) {
+        matched = found
+        break
+      }
+    }
+    if (!matched) {
+      console.warn('[WorkPlanView] 매칭되는 trade_process 없음:', w)
+      orphans.push(w)
+      continue
+    }
+
+    if (filterStatus.value && workPlanStatus(w) !== filterStatus.value) continue
+
+    matched.workPlans.push({
+      id: w.id,
+      name: w.name,
+      location: w.location || '',
+      start: w.start,
+      end: effectiveEnd(w),
+      status: workPlanStatus(w),
+      raw: w,
+    })
+  }
+
+  // work_plan이 없는 공정은 기준 일정을 기본 실행 일정으로 세팅
+  for (const arr of tradeMap.values()) {
+    for (const item of arr) {
+      if (item.workPlans.length === 0 && item.baselineStart && item.baselineEnd) {
+        item.workPlans.push({
+          id: `__default-${item.id}`,
+          name: item.name,
+          location: '기본 실행 일정',
+          start: item.baselineStart,
+          end: item.baselineEnd,
+          status: '진행 예정',
+          isDefault: true, // 기준 일정에서 복제된 기본값임을 표시
+          raw: null,
+        })
+      }
+    }
+  }
+
+  // 그룹 배열로 변환
+  const groups = []
+  for (const [trade, items] of tradeMap.entries()) {
+    groups.push({ group: trade, items })
+  }
+
+  // 미연결 실행계획 그룹
+  if (orphans.length) {
+    groups.push({
+      group: '미연결 실행계획',
+      isOrphan: true,
+      items: [
+        {
+          id: '__orphan__',
+          tradeProcessId: null,
+          name: '기준 공정에 연결되지 않은 실행계획',
+          trade: '미연결',
+          weightPct: null,
+          baselineStart: null,
+          baselineEnd: null,
+          isMilestone: false,
+          workPlans: orphans.map((w) => ({
+            id: w.id,
+            name: w.name,
+            location: w.location || '',
+            start: w.start,
+            end: effectiveEnd(w),
+            status: workPlanStatus(w),
+            raw: w,
+          })),
+        },
+      ],
+    })
+  }
+
+  return groups
+}
+
+// 월간 work_plan에서 "월간계획서 기준 일정"(파란선) 가져오기
+// 백엔드 스키마 변경 전: plannedStart/plannedEnd 없으면 실행 start/end로 폴백 (두 선이 겹쳐 보임)
+function workPlanPlannedStart(w) {
+  return w.plannedStart ?? w.planned_start ?? w.start ?? null
+}
+function workPlanPlannedEnd(w) {
+  return w.plannedEnd ?? w.planned_end ?? effectiveEnd(w) ?? null
+}
+
+// 연간 work_plan들에서 공정별 "마일스톤 종료일" 계산
+// = 같은 tradeProcessId의 연간 work_plan들 중 가장 늦은 종료일
+function buildProcessMilestones() {
+  const m = new Map() // tradeProcessId -> { date, source }
+  for (const w of annualPlans.value) {
+    const tpid = workPlanTradeProcessId(w)
+    if (tpid == null) continue
+    const end = effectiveEnd(w)
+    if (!end) continue
+    const prev = m.get(tpid)
+    if (!prev || end > prev.date) {
+      m.set(tpid, { date: end, source: w })
+    }
+  }
+  return m
+}
+
+// 월간 전용: 공종 → 공정 → 세부계획(work_plan) 3단 구조
+// 연간 buildGroups와 차이점:
+//  - 공정 행: baseline 막대가 아닌 "마일스톤 점"(연간 빨간선 종료일) 표시
+//  - 세부계획 행: 파란선(월간계획서 기준 plannedStart/End) + 빨간선(실행 start/end)
+function buildMonthlyGroups(plans) {
+  const tradeMap = new Map()
+  const milestones = buildProcessMilestones()
+
+  // 1) baseline(trade_process) 기준으로 공종 → 공정 골격 생성
+  for (const b of baselinePlans.value) {
+    if (filterTrade.value && baseTradeName(b) !== filterTrade.value) continue
+    const trade = baseTradeName(b)
+    const tpid = baseId(b)
+    if (!tradeMap.has(trade)) tradeMap.set(trade, [])
+    const milestone = milestones.get(tpid)
+    tradeMap.get(trade).push({
+      id: tpid,
+      tradeProcessId: tpid,
+      name: baseProcessName(b),
+      trade,
+      weightPct: baseWeight(b),
+      baselineStart: baseStart(b),
+      baselineEnd: baseEnd(b),
+      // 공정 마일스톤: 연간 work_plan의 가장 늦은 종료일 (없으면 baselineEnd)
+      milestoneDate: milestone ? milestone.date : baseEnd(b),
+      milestoneFromAnnual: !!milestone,
+      isMilestone: baseIsMilestone(b),
+      raw: b,
+      details: [], // 세부계획(월간 work_plan)들
+    })
+  }
+
+  // 2) 월간 work_plan들을 세부계획으로 매칭
+  const orphans = []
+  for (const w of plans) {
+    const tpid = workPlanTradeProcessId(w)
+    if (tpid == null) {
+      orphans.push(w)
+      continue
+    }
+    let matched = null
+    for (const arr of tradeMap.values()) {
+      const found = arr.find((it) => it.tradeProcessId === tpid)
+      if (found) {
+        matched = found
+        break
+      }
+    }
+    if (!matched) {
+      orphans.push(w)
+      continue
+    }
+    if (filterStatus.value && workPlanStatus(w) !== filterStatus.value) continue
+
+    matched.details.push({
+      id: w.id,
+      name: w.name || '(세부계획명 없음)',
+      location: w.location || '',
+      // 파란선 = 월간계획서 기준 일정
+      plannedStart: workPlanPlannedStart(w),
+      plannedEnd: workPlanPlannedEnd(w),
+      // 빨간선 = 실행 일정 (주간/지시서/일보로 갱신됨)
+      start: w.start,
+      end: effectiveEnd(w),
+      status: workPlanStatus(w),
+      raw: w,
+    })
+  }
+
+  // 3) 그룹 배열로 변환
+  const groups = []
+  for (const [trade, items] of tradeMap.entries()) {
+    groups.push({ group: trade, items })
+  }
+
+  // 4) 미연결 실행계획
+  if (orphans.length) {
+    groups.push({
+      group: '미연결 실행계획',
+      isOrphan: true,
+      items: [
+        {
+          id: '__orphan__',
+          tradeProcessId: null,
+          name: '기준 공정에 연결되지 않은 세부계획',
+          trade: '미연결',
+          weightPct: null,
+          baselineStart: null,
+          baselineEnd: null,
+          milestoneDate: null,
+          milestoneFromAnnual: false,
+          isMilestone: false,
+          details: orphans.map((w) => ({
+            id: w.id,
+            name: w.name,
+            location: w.location || '',
+            plannedStart: workPlanPlannedStart(w),
+            plannedEnd: workPlanPlannedEnd(w),
+            start: w.start,
+            end: effectiveEnd(w),
+            status: workPlanStatus(w),
+            raw: w,
+          })),
+        },
+      ],
+    })
+  }
+
+  return groups
+}
+
+// 연간: 공종 → 공정 → 위치별 실행계획 (3단)
+const yearlyGroups = computed(() => buildGroups(annualPlans.value))
+// 월간: 공종 → 공정(마일스톤) → 세부계획(파란/빨간선) (3단)
+const monthlyGroups = computed(() => buildMonthlyGroups(monthlyPlans.value))
+
+// 공종 그룹 펼침 상태
+const groupOpen = ref({})
+
+// 월간: 공정별 펼침 상태 (공정 ID 기준)
+const monthlyProcessOpen = ref({})
+
+watch(
+  [yearlyGroups, monthlyGroups],
+  () => {
+    const all = [...yearlyGroups.value, ...monthlyGroups.value]
+    for (const g of all) {
+      if (groupOpen.value[g.group] === undefined) {
+        groupOpen.value[g.group] = true
+      }
+    }
+    // 월간 공정 펼침 상태 초기화 (기본: 펼쳐짐)
+    for (const g of monthlyGroups.value) {
+      for (const item of g.items) {
+        if (monthlyProcessOpen.value[item.id] === undefined) {
+          monthlyProcessOpen.value[item.id] = true
+        }
+      }
+    }
+  },
+  { immediate: true },
+)
+
+// 공정 한 줄의 고정 높이 (좌측 컨텐츠와 우측 차트 행이 정확히 일치하도록)
+// 좌측 컨텐츠 실측:
+//   - py-2 위아래 = 16px
+//   - 공정명 줄 = 20px
+//   - 기준기간 줄 = 14px
+//   - gap-0.5 = 2px × 2 = 4px
+//   - workPlans ul: mt-1 (4px) + 각 wp 14px + space-y-0.5 (2px)
+// 우측 차트:
+//   - 기준선 top:14, 실행선 top:34부터 20px 간격
+function processRowHeight(item) {
+  const wp = item.workPlans?.length || 0
+  // 헤더부(공정명+기준기간+padding) 약 60px + workPlans 영역
+  const wpArea = wp === 0 ? 18 : 4 + wp * 18 // mt-1 + 줄당 약 18px
+  const left = 60 + wpArea
+  // 우측 차트가 모든 실행선을 보여주려면 (workPlanTop(last) + 6) 이상 필요
+  const right = wp === 0 ? 48 : workPlanTop(wp - 1) + 14
+  return Math.max(left, right, 56)
+}
+
+// 월간: 공정 헤더 행 한 줄 높이 (공정명 + 마일스톤 표시)
+const MONTHLY_PROCESS_HEADER_H = 44
+// 월간: 세부계획 한 줄 높이 (파란선 + 빨간선 한 쌍 들어갈 공간)
+const MONTHLY_DETAIL_ROW_H = 32
+
+function monthlyProcessHeaderHeight() {
+  return MONTHLY_PROCESS_HEADER_H
+}
+function monthlyDetailRowHeight() {
+  return MONTHLY_DETAIL_ROW_H
+}
+
+// work_plan 실행선의 top 위치
+function workPlanTop(idx) {
+  return 34 + idx * 20
+}
+
+// 기준선 클릭 (수정 불가 안내)
+function onClickBaseline(item) {
+  selectedPlan.value = {
+    __baseline: true,
+    id: `base-${item.id}`,
+    name: item.name,
+    trade: item.trade,
+    start: item.baselineStart,
+    end: item.baselineEnd,
+    weightPct: item.weightPct,
+    location: '',
+  }
+}
+
+// 실행선 클릭 (기존 selectedPlan 동작)
+function onClickWorkPlan(wp) {
+  if (wp.isDefault) {
+    // 기본 실행 일정 = 기준 일정과 동일하므로 baseline 안내로 표시
+    selectedPlan.value = {
+      __baseline: true,
+      id: `default-${wp.id}`,
+      name: wp.name,
+      trade: '',
+      start: wp.start,
+      end: wp.end,
+      weightPct: null,
+      location: wp.location,
+    }
+    return
+  }
+  selectedPlan.value = wp.raw
 }
 </script>
 
@@ -1064,136 +1647,167 @@ function selectViewMode(mode) {
                 </p>
               </div>
               <span
+                v-if="!selectedPlan.__baseline"
                 class="shrink-0 rounded-lg px-2.5 py-1 text-xs font-bold"
                 :class="statusClass(workPlanStatus(selectedPlan))"
                 >{{ workPlanStatus(selectedPlan) }}</span
               >
+              <span
+                v-else
+                class="shrink-0 rounded-lg bg-blue-50 px-2.5 py-1 text-xs font-bold text-blue-700 ring-1 ring-blue-200"
+              >
+                기준 일정
+              </span>
             </div>
 
+            <!-- 기준 일정 (trade_process) 안내 배너 -->
             <div
-              v-if="selectedPlan.planType === '주간'"
-              class="mb-4 rounded-xl border border-forena-100 bg-white p-3.5"
+              v-if="selectedPlan.__baseline"
+              class="mb-4 flex items-start gap-2 rounded-xl border border-blue-200 bg-blue-50/60 p-3"
             >
-              <div class="mb-3 flex items-center gap-1.5">
-                <ClipboardList class="h-3.5 w-3.5 text-flare-600" />
-                <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
-                  >주간 계획서 정보</span
-                >
-              </div>
-              <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                <div class="rounded-lg bg-forena-50/60 px-3 py-2">
-                  <p class="text-[10px] font-bold text-forena-400">협력사</p>
-                  <p class="mt-1 text-sm font-semibold text-forena-900">
-                    {{ selectedPlan.partner || '-' }}
-                  </p>
-                </div>
-                <div class="rounded-lg bg-forena-50/60 px-3 py-2">
-                  <p class="text-[10px] font-bold text-forena-400">담당자</p>
-                  <p class="mt-1 text-sm font-semibold text-forena-900">
-                    {{ selectedPlan.manager || '-' }}
-                  </p>
-                </div>
-                <div class="rounded-lg bg-forena-50/60 px-3 py-2">
-                  <p class="text-[10px] font-bold text-forena-400">연락처</p>
-                  <p class="mt-1 text-sm font-semibold text-forena-900">
-                    {{ selectedPlan.contact || '-' }}
-                  </p>
-                </div>
-                <div class="rounded-lg bg-forena-50/60 px-3 py-2">
-                  <p class="text-[10px] font-bold text-forena-400">주 시작일</p>
-                  <p class="mt-1 text-sm font-semibold tabular-nums text-forena-900">
-                    {{ displayWeekStart(selectedPlan) }}
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <!-- ★ 연장 알림 박스 -->
-            <div
-              v-if="extOf(selectedPlan)"
-              class="mb-4 flex items-start gap-2.5 rounded-xl border border-emerald-200 bg-emerald-50/50 p-3.5"
-            >
-              <CalendarPlus class="h-4 w-4 shrink-0 text-emerald-600 mt-0.5" />
-              <div class="flex-1">
-                <p class="text-xs font-bold text-emerald-700">공정 분석을 통한 일정 연장</p>
-                <p class="mt-1 text-[11px] text-emerald-800">
-                  종료일 <span class="font-bold tabular-nums">{{ selectedPlan.end }}</span> →
-                  <span class="font-bold tabular-nums">{{ extOf(selectedPlan).extendedEnd }}</span>
-                  (+{{ extOf(selectedPlan).addedDays }}일)
-                </p>
-                <p
-                  v-if="extOf(selectedPlan).reason"
-                  class="mt-1 text-[11px] text-emerald-700/80 leading-relaxed"
-                >
-                  {{ extOf(selectedPlan).reason }}
-                </p>
-                <p class="mt-1 text-[10px] text-emerald-600">
-                  반영 {{ extOf(selectedPlan).decidedAt }}
+              <AlertTriangle class="mt-0.5 h-4 w-4 shrink-0 text-blue-600" />
+              <div class="text-[12px] leading-5 text-blue-800">
+                <p class="font-bold">전체 공정표 기준 일정입니다</p>
+                <p class="mt-0.5 text-blue-700">
+                  이 일정은 최초 공정표에서 생성된 기준 데이터로, 화면에서 직접 수정할 수 없습니다.
+                  실행 일정을 조정하려면 하위의 빨간 실행/진행선(연간/월간 작업계획)을 선택해
+                  주세요.
+                  <span v-if="selectedPlan.weightPct != null"
+                    >· 보할율 {{ selectedPlan.weightPct }}%</span
+                  >
                 </p>
               </div>
             </div>
 
-            <div class="grid gap-3 sm:grid-cols-3">
-              <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
-                <div class="flex items-center gap-1.5 mb-2">
-                  <MapPin class="h-3.5 w-3.5 text-flare-600" />
+            <!-- work_plan 전용 상세 (baseline일 땐 숨김) -->
+            <template v-if="!selectedPlan.__baseline">
+              <div
+                v-if="selectedPlan.planType === '주간'"
+                class="mb-4 rounded-xl border border-forena-100 bg-white p-3.5"
+              >
+                <div class="mb-3 flex items-center gap-1.5">
+                  <ClipboardList class="h-3.5 w-3.5 text-flare-600" />
                   <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
-                    >작업 위치</span
+                    >주간 계획서 정보</span
                   >
                 </div>
-                <p class="text-sm font-semibold text-forena-900">{{ selectedPlan.location }}</p>
-              </div>
-              <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
-                <div class="flex items-center gap-1.5 mb-2">
-                  <Users class="h-3.5 w-3.5 text-flare-600" />
-                  <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
-                    >필요 인원</span
-                  >
-                </div>
-                <ul v-if="selectedPlan.workers && selectedPlan.workers.length" class="space-y-1">
-                  <li
-                    v-for="(w, i) in selectedPlan.workers"
-                    :key="i"
-                    class="flex items-baseline justify-between text-sm"
-                  >
-                    <span class="font-semibold text-forena-900">{{ w.trade }}</span>
-                    <span class="tabular-nums text-forena-700">{{ w.count }}명</span>
-                  </li>
-                </ul>
-                <p v-else class="text-sm text-slate-400">해당 없음</p>
-                <div
-                  v-if="selectedPlan.requiredCount"
-                  class="mt-2 flex items-baseline justify-between border-t border-forena-100 pt-1.5"
-                >
-                  <span class="text-[10px] font-bold uppercase text-forena-400">합계</span>
-                  <span class="text-xs font-bold tabular-nums text-flare-700">
-                    {{ selectedPlan.requiredCount }}명
-                  </span>
+                <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                  <div class="rounded-lg bg-forena-50/60 px-3 py-2">
+                    <p class="text-[10px] font-bold text-forena-400">협력사</p>
+                    <p class="mt-1 text-sm font-semibold text-forena-900">
+                      {{ selectedPlan.partner || '-' }}
+                    </p>
+                  </div>
+                  <div class="rounded-lg bg-forena-50/60 px-3 py-2">
+                    <p class="text-[10px] font-bold text-forena-400">담당자</p>
+                    <p class="mt-1 text-sm font-semibold text-forena-900">
+                      {{ selectedPlan.manager || '-' }}
+                    </p>
+                  </div>
+                  <div class="rounded-lg bg-forena-50/60 px-3 py-2">
+                    <p class="text-[10px] font-bold text-forena-400">연락처</p>
+                    <p class="mt-1 text-sm font-semibold text-forena-900">
+                      {{ selectedPlan.contact || '-' }}
+                    </p>
+                  </div>
+                  <div class="rounded-lg bg-forena-50/60 px-3 py-2">
+                    <p class="text-[10px] font-bold text-forena-400">주 시작일</p>
+                    <p class="mt-1 text-sm font-semibold tabular-nums text-forena-900">
+                      {{ displayWeekStart(selectedPlan) }}
+                    </p>
+                  </div>
                 </div>
               </div>
-              <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
-                <div class="flex items-center gap-1.5 mb-2">
-                  <Wrench class="h-3.5 w-3.5 text-flare-600" />
-                  <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
-                    >필요 장비</span
+
+              <!-- ★ 연장 알림 박스 -->
+              <div
+                v-if="extOf(selectedPlan)"
+                class="mb-4 flex items-start gap-2.5 rounded-xl border border-emerald-200 bg-emerald-50/50 p-3.5"
+              >
+                <CalendarPlus class="h-4 w-4 shrink-0 text-emerald-600 mt-0.5" />
+                <div class="flex-1">
+                  <p class="text-xs font-bold text-emerald-700">공정 분석을 통한 일정 연장</p>
+                  <p class="mt-1 text-[11px] text-emerald-800">
+                    종료일 <span class="font-bold tabular-nums">{{ selectedPlan.end }}</span> →
+                    <span class="font-bold tabular-nums">{{
+                      extOf(selectedPlan).extendedEnd
+                    }}</span>
+                    (+{{ extOf(selectedPlan).addedDays }}일)
+                  </p>
+                  <p
+                    v-if="extOf(selectedPlan).reason"
+                    class="mt-1 text-[11px] text-emerald-700/80 leading-relaxed"
                   >
+                    {{ extOf(selectedPlan).reason }}
+                  </p>
+                  <p class="mt-1 text-[10px] text-emerald-600">
+                    반영 {{ extOf(selectedPlan).decidedAt }}
+                  </p>
                 </div>
-                <ul
-                  v-if="selectedPlan.equipment && selectedPlan.equipment.length"
-                  class="space-y-1"
-                >
-                  <li
-                    v-for="(eq, i) in selectedPlan.equipment"
-                    :key="i"
-                    class="flex items-baseline justify-between text-sm"
-                  >
-                    <span class="font-semibold text-forena-900">{{ eq.type }}</span>
-                    <span class="tabular-nums text-forena-700">{{ eq.count }}대</span>
-                  </li>
-                </ul>
-                <p v-else class="text-sm text-slate-400">해당 없음</p>
               </div>
-            </div>
+
+              <div class="grid gap-3 sm:grid-cols-3">
+                <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
+                  <div class="flex items-center gap-1.5 mb-2">
+                    <MapPin class="h-3.5 w-3.5 text-flare-600" />
+                    <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
+                      >작업 위치</span
+                    >
+                  </div>
+                  <p class="text-sm font-semibold text-forena-900">{{ selectedPlan.location }}</p>
+                </div>
+                <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
+                  <div class="flex items-center gap-1.5 mb-2">
+                    <Users class="h-3.5 w-3.5 text-flare-600" />
+                    <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
+                      >필요 인원</span
+                    >
+                  </div>
+                  <ul v-if="selectedPlan.workers && selectedPlan.workers.length" class="space-y-1">
+                    <li
+                      v-for="(w, i) in selectedPlan.workers"
+                      :key="i"
+                      class="flex items-baseline justify-between text-sm"
+                    >
+                      <span class="font-semibold text-forena-900">{{ w.trade }}</span>
+                      <span class="tabular-nums text-forena-700">{{ w.count }}명</span>
+                    </li>
+                  </ul>
+                  <p v-else class="text-sm text-slate-400">해당 없음</p>
+                  <div
+                    v-if="selectedPlan.requiredCount"
+                    class="mt-2 flex items-baseline justify-between border-t border-forena-100 pt-1.5"
+                  >
+                    <span class="text-[10px] font-bold uppercase text-forena-400">합계</span>
+                    <span class="text-xs font-bold tabular-nums text-flare-700">
+                      {{ selectedPlan.requiredCount }}명
+                    </span>
+                  </div>
+                </div>
+                <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
+                  <div class="flex items-center gap-1.5 mb-2">
+                    <Wrench class="h-3.5 w-3.5 text-flare-600" />
+                    <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
+                      >필요 장비</span
+                    >
+                  </div>
+                  <ul
+                    v-if="selectedPlan.equipment && selectedPlan.equipment.length"
+                    class="space-y-1"
+                  >
+                    <li
+                      v-for="(eq, i) in selectedPlan.equipment"
+                      :key="i"
+                      class="flex items-baseline justify-between text-sm"
+                    >
+                      <span class="font-semibold text-forena-900">{{ eq.type }}</span>
+                      <span class="tabular-nums text-forena-700">{{ eq.count }}대</span>
+                    </li>
+                  </ul>
+                  <p v-else class="text-sm text-slate-400">해당 없음</p>
+                </div>
+              </div>
+            </template>
           </div>
         </template>
 
@@ -1215,10 +1829,27 @@ function selectViewMode(mode) {
               <!-- 간트차트 범례 -->
               <div v-if="viewMode !== 'weekly'" class="flex items-center gap-3 text-[10px]">
                 <span class="flex items-center gap-1.5 text-forena-500">
-                  <span class="h-[3px] w-5 rounded-full bg-violet-600"></span>계획서 기준
+                  <span class="h-[3px] w-5 rounded-full bg-blue-600"></span>전체 공정표 기준
                 </span>
                 <span class="flex items-center gap-1.5 text-forena-500">
-                  <span class="h-[3px] w-5 rounded-full bg-green-700"></span>실제/예상 진행
+                  <span class="relative h-[3px] w-5 rounded-full bg-red-200">
+                    <span class="absolute inset-y-0 left-0 w-1/2 rounded-full bg-red-500"></span>
+                  </span>
+                  {{ viewMode === 'yearly' ? '연간' : '월간' }} 실행/진행
+                </span>
+                <span class="flex items-center gap-1.5 text-forena-500">
+                  <svg class="h-3 w-3" viewBox="0 0 12 12">
+                    <path
+                      d="M6 1 L11 6 L6 11 L1 6 Z"
+                      fill="#f59e0b"
+                      stroke="#b45309"
+                      stroke-width="1"
+                    />
+                  </svg>
+                  마일스톤
+                </span>
+                <span class="flex items-center gap-1.5 text-forena-500">
+                  <span class="h-3 w-px bg-flare-500"></span>오늘
                 </span>
               </div>
 
@@ -1382,47 +2013,83 @@ function selectViewMode(mode) {
           </div>
 
           <!-- ========== 연간 (간트차트) ========== -->
+          <!-- 구조: 공종 그룹 → 공정(파란 기준선) → 위치별 실행계획(빨간 실행/진행선들) -->
           <div v-else-if="viewMode === 'yearly'" class="min-h-0 flex-1 overflow-auto bg-white">
             <div
-              v-if="!yearlyPlans.length"
+              v-if="!yearlyGroups.length"
               class="flex items-center justify-center py-16 text-sm text-slate-400"
             >
-              {{ yearMeta.year }}년에 표시할 작업이 없습니다.
+              {{ yearMeta.year }}년에 표시할 기준 공정이 없습니다.
             </div>
 
             <div v-else class="flex min-w-max">
+              <!-- 좌측: 공종 그룹 → 공정 → 실행계획 목록 -->
               <div
                 class="sticky left-0 z-10 shrink-0 border-r border-forena-200 bg-white"
                 :style="{ width: NAME_COL_W + 'px' }"
               >
                 <div class="flex h-10 items-center border-b border-forena-200 bg-white px-4">
-                  <span class="text-[11px] font-bold text-forena-500">공정명 / 공종</span>
+                  <span class="text-[11px] font-bold text-forena-500">공종 / 공정 / 실행위치</span>
                 </div>
-                <div
-                  v-for="p in yearlyPlans"
-                  :key="p.id"
-                  class="flex h-[68px] cursor-pointer flex-col justify-center gap-0.5 border-b border-forena-100 px-4 transition hover:bg-forena-50/60"
-                  :class="selectedPlan?.id === p.id ? 'bg-flare-50/60' : ''"
-                  @click="selectedPlan = p"
-                >
-                  <div class="flex items-center gap-1.5">
-                    <p class="truncate text-sm font-bold text-forena-900">{{ p.name }}</p>
+
+                <template v-for="grp in yearlyGroups" :key="`y-grp-${grp.group}`">
+                  <!-- 공종 그룹 헤더 (접기/펼치기) -->
+                  <div
+                    class="flex h-9 cursor-pointer items-center justify-between border-b border-forena-200 bg-gradient-to-r from-forena-100 to-forena-50 px-3 text-[11px] font-bold text-forena-800 transition hover:from-flare-50 hover:to-flare-50/30"
+                    @click="groupOpen[grp.group] = !groupOpen[grp.group]"
+                  >
+                    <div class="flex items-center gap-1.5">
+                      <ChevronDown
+                        v-if="groupOpen[grp.group]"
+                        class="h-3.5 w-3.5 text-forena-600"
+                      />
+                      <ChevronRight v-else class="h-3.5 w-3.5 text-forena-600" />
+                      <span>{{ grp.group }}</span>
+                    </div>
                     <span
-                      v-if="extOf(p)"
-                      class="inline-flex items-center gap-0.5 rounded bg-emerald-50 px-1 py-0.5 text-[9px] font-bold text-emerald-700"
+                      class="rounded bg-white/70 px-1.5 py-0.5 text-[9px] tabular-nums text-forena-500"
+                      >{{ grp.items.length }}</span
                     >
-                      <CalendarPlus class="h-2.5 w-2.5" />+{{ extOf(p).addedDays }}일
-                    </span>
                   </div>
-                  <p class="truncate text-[11px] text-forena-500">
-                    {{ p.trade }}{{ p.location ? ` / ${p.location}` : '' }}
-                  </p>
-                  <p v-if="p.sourceFile" class="truncate text-[10px] text-slate-400">
-                    출처 문서: {{ p.sourceFile }}
-                  </p>
-                </div>
+
+                  <template v-if="groupOpen[grp.group]">
+                    <div
+                      v-for="item in grp.items"
+                      :key="`y-item-${item.id}`"
+                      class="flex cursor-pointer flex-col justify-start gap-0.5 overflow-hidden border-b border-forena-100 px-4 py-2 transition hover:bg-forena-50/60"
+                      :style="{ height: processRowHeight(item) + 'px' }"
+                    >
+                      <!-- 공정명 + 보할 -->
+                      <div class="flex items-center gap-1.5" @click="onClickBaseline(item)">
+                        <p class="truncate text-sm font-bold text-forena-900">{{ item.name }}</p>
+                        <span
+                          v-if="item.weightPct != null"
+                          class="rounded bg-blue-50 px-1 py-0.5 text-[9px] font-bold text-blue-700"
+                        >
+                          보할 {{ item.weightPct }}%
+                        </span>
+                      </div>
+                      <p class="truncate text-[10px] text-slate-400">
+                        기준 {{ item.baselineStart || '-' }} ~ {{ item.baselineEnd || '-' }}
+                      </p>
+                      <!-- 하위 work_plan 위치 목록 -->
+                      <ul v-if="item.workPlans.length" class="mt-1 space-y-0.5">
+                        <li
+                          v-for="wp in item.workPlans"
+                          :key="`y-wp-${wp.id}`"
+                          class="truncate text-[10px] text-red-600 hover:text-red-700"
+                          @click.stop="onClickWorkPlan(wp)"
+                        >
+                          └ {{ wp.location || wp.name }} 실행
+                        </li>
+                      </ul>
+                      <p v-else class="text-[10px] italic text-slate-300">실행 일정 없음</p>
+                    </div>
+                  </template>
+                </template>
               </div>
 
+              <!-- 우측: 차트 (공종 헤더 라인 + 공정 행마다 파란선 + 빨간 실행/진행선들) -->
               <div class="relative" :style="{ width: yearChartWidth + 'px' }">
                 <div class="sticky top-0 z-[5] flex h-10 border-b border-forena-200 bg-white">
                   <div
@@ -1437,118 +2104,220 @@ function selectViewMode(mode) {
                 </div>
 
                 <div class="relative">
-                  <div
-                    v-for="p in yearlyPlans"
-                    :key="p.id"
-                    class="relative flex h-[68px] border-b border-forena-100"
-                    :class="selectedPlan?.id === p.id ? 'bg-flare-50/40' : ''"
-                  >
+                  <template v-for="grp in yearlyGroups" :key="`y-grow-${grp.group}`">
+                    <!-- 공종 그룹 헤더 (오른쪽 빈 영역 - 좌측과 높이 매칭) -->
                     <div
-                      v-for="m in yearMeta.months"
-                      :key="m.month"
-                      class="border-r border-forena-50"
-                      :style="{ width: GANTT_MONTH_W + 'px' }"
+                      class="h-9 border-b border-forena-200 bg-gradient-to-r from-forena-100 to-forena-50"
                     ></div>
 
-                    <div
-                      v-if="yearBarStyle(p.start, p.end)"
-                      class="group absolute z-[2] flex cursor-pointer items-center"
-                      :style="{ ...yearBarStyle(p.start, p.end), top: '20px', height: '4px' }"
-                      :title="`계획서 기준: ${p.start} ~ ${p.end}`"
-                      @click="selectedPlan = p"
-                    >
-                      <span
-                        class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-violet-600 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-violet-600 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="h-1 w-full rounded-full bg-violet-600 transition group-hover:h-1.5"
-                      ></span>
-                    </div>
+                    <template v-if="groupOpen[grp.group]">
+                      <div
+                        v-for="item in grp.items"
+                        :key="`y-row-${item.id}`"
+                        class="relative flex border-b border-forena-100"
+                        :style="{ height: processRowHeight(item) + 'px' }"
+                      >
+                        <!-- 월 셀 그리드 -->
+                        <div
+                          v-for="m in yearMeta.months"
+                          :key="m.month"
+                          class="border-r border-forena-50"
+                          :style="{ width: GANTT_MONTH_W + 'px' }"
+                        ></div>
 
-                    <div
-                      v-if="yearBarStyle(actualLineRange(p).start, actualLineRange(p).end)"
-                      class="absolute z-[1] flex cursor-pointer items-center"
-                      :style="{
-                        ...yearBarStyle(actualLineRange(p).start, actualLineRange(p).end),
-                        top: '40px',
-                        height: '4px',
-                      }"
-                      :title="`실제/예상 진행: ${actualLineRange(p).start} ~ ${actualLineRange(p).end}`"
-                      @click="selectedPlan = p"
-                    >
-                      <span class="h-1 w-full rounded-full bg-green-300"></span>
-                    </div>
-                    <div
-                      v-if="
-                        progressFillEnd(p) &&
-                        yearBarStyle(actualLineRange(p).start, progressFillEnd(p))
-                      "
-                      class="absolute z-[2] flex cursor-pointer items-center"
-                      :style="{
-                        ...yearBarStyle(actualLineRange(p).start, progressFillEnd(p)),
-                        top: '40px',
-                        height: '4px',
-                      }"
-                      @click="selectedPlan = p"
-                    >
-                      <span
-                        class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-green-700 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-green-700 ring-2 ring-white"
-                      ></span>
-                      <span class="h-1 w-full rounded-full bg-green-700"></span>
-                    </div>
-                  </div>
+                        <!-- 마일스톤 (있을 경우) -->
+                        <!-- baseline 시작점에 다이아몬드 표시 -->
+
+                        <!-- 파란색: 기준 일정 (trade_process) -->
+                        <div
+                          v-if="
+                            item.baselineStart &&
+                            item.baselineEnd &&
+                            yearBarStyle(item.baselineStart, item.baselineEnd)
+                          "
+                          class="group absolute z-[2] flex cursor-pointer items-center"
+                          :style="{
+                            ...yearBarStyle(item.baselineStart, item.baselineEnd),
+                            top: '14px',
+                            height: '4px',
+                          }"
+                          :title="`기준 일정 (수정 불가): ${item.baselineStart} ~ ${item.baselineEnd}`"
+                          @click="onClickBaseline(item)"
+                        >
+                          <span
+                            class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-blue-600 ring-2 ring-white"
+                          ></span>
+                          <span
+                            class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-blue-600 ring-2 ring-white"
+                          ></span>
+                          <span class="h-1 w-full rounded-full bg-blue-600"></span>
+                        </div>
+
+                        <!-- 빨간색: 위치별 실행 일정 + 진행률 (work_plan) - 여러 줄 -->
+                        <div
+                          v-for="(wp, wi) in item.workPlans"
+                          :key="`y-wpbar-${wp.id}`"
+                          class="group absolute z-[2] cursor-pointer"
+                          :style="{
+                            ...(yearBarStyle(wp.start, wp.end) || { display: 'none' }),
+                            top: workPlanTop(wi) + 'px',
+                            height: '4px',
+                          }"
+                          :title="`${wp.name}${wp.location ? ' · ' + wp.location : ''}\n${wp.start} ~ ${wp.end}`"
+                          @click.stop="onClickWorkPlan(wp)"
+                        >
+                          <!-- 실행 일정 시작점 -->
+                          <span
+                            class="absolute -left-[3px] top-1/2 z-[3] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                          ></span>
+
+                          <!-- 실행 일정 종료점 -->
+                          <span
+                            class="absolute -right-[3px] top-1/2 z-[3] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                          ></span>
+
+                          <!-- 실행 일정 전체 기간: 연한 빨간색 -->
+                          <span class="absolute inset-0 z-0 rounded-full bg-red-200"></span>
+
+                          <!-- 진행률 게이지: 진한 빨간색 -->
+                          <span
+                            class="absolute inset-y-0 left-0 z-[1] rounded-full bg-red-500 transition group-hover:h-1.5"
+                            :style="progressBarStyle(wp, yearBarStyle)"
+                          ></span>
+
+                          <!-- 진행률 위치 점 -->
+                          <span
+                            class="absolute top-1/2 z-[4] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                            :style="progressDotStyle(wp, yearBarStyle)"
+                          ></span>
+                        </div>
+                      </div>
+                    </template>
+                  </template>
                 </div>
               </div>
             </div>
           </div>
 
           <!-- ========== 월간 (라인형 간트차트) ========== -->
+          <!-- 구조: 공종 그룹 → 공정 행(접기/펼치기, 마일스톤) → 세부계획 행들(파란 월간기준선 + 빨간 실행선) -->
           <div v-else class="min-h-0 flex-1 overflow-auto bg-white">
             <div
-              v-if="!ganttPlans.length"
+              v-if="!monthlyGroups.length"
               class="flex items-center justify-center py-16 text-sm text-slate-400"
             >
-              {{ monthMeta.year }}년 {{ monthMeta.month }}월에 표시할 작업이 없습니다.
+              {{ monthMeta.year }}년 {{ monthMeta.month }}월에 표시할 기준 공정이 없습니다.
             </div>
 
             <div v-else class="flex min-w-max">
-              <!-- 좌측: 작업명 -->
+              <!-- 좌측: 공종 → 공정 → 세부계획 목록 -->
               <div
                 class="sticky left-0 z-10 shrink-0 border-r border-forena-200 bg-white"
                 :style="{ width: NAME_COL_W + 'px' }"
               >
                 <div class="flex h-10 items-center border-b border-forena-200 bg-white px-4">
-                  <span class="text-[11px] font-bold text-forena-500">공정명 / 공종</span>
+                  <span class="text-[11px] font-bold text-forena-500">공종 / 공정 / 세부계획</span>
                 </div>
-                <div
-                  v-for="p in ganttPlans"
-                  :key="p.id"
-                  class="flex h-[68px] cursor-pointer flex-col justify-center gap-0.5 border-b border-forena-100 px-4 transition hover:bg-forena-50/60"
-                  :class="selectedPlan?.id === p.id ? 'bg-flare-50/60' : ''"
-                  @click="selectedPlan = p"
-                >
-                  <div class="flex items-center gap-1.5">
-                    <p class="truncate text-sm font-bold text-forena-900">{{ p.name }}</p>
+
+                <template v-for="grp in monthlyGroups" :key="`m-grp-${grp.group}`">
+                  <!-- 공종 그룹 헤더 -->
+                  <div
+                    class="flex h-9 cursor-pointer items-center justify-between border-b border-forena-200 bg-gradient-to-r from-forena-100 to-forena-50 px-3 text-[11px] font-bold text-forena-800 transition hover:from-flare-50 hover:to-flare-50/30"
+                    @click="groupOpen[grp.group] = !groupOpen[grp.group]"
+                  >
+                    <div class="flex items-center gap-1.5">
+                      <ChevronDown
+                        v-if="groupOpen[grp.group]"
+                        class="h-3.5 w-3.5 text-forena-600"
+                      />
+                      <ChevronRight v-else class="h-3.5 w-3.5 text-forena-600" />
+                      <span>{{ grp.group }}</span>
+                    </div>
                     <span
-                      v-if="extOf(p)"
-                      class="inline-flex items-center gap-0.5 rounded bg-emerald-50 px-1 py-0.5 text-[9px] font-bold text-emerald-700"
+                      class="rounded bg-white/70 px-1.5 py-0.5 text-[9px] tabular-nums text-forena-500"
+                      >{{ grp.items.length }}</span
                     >
-                      <CalendarPlus class="h-2.5 w-2.5" />+{{ extOf(p).addedDays }}일
-                    </span>
                   </div>
-                  <p class="truncate text-[11px] text-forena-500">
-                    {{ p.trade }}{{ p.location ? ` / ${p.location}` : '' }}
-                  </p>
-                  <p v-if="p.sourceFile" class="truncate text-[10px] text-slate-400">
-                    출처 문서: {{ p.sourceFile }}
-                  </p>
-                </div>
+
+                  <template v-if="groupOpen[grp.group]">
+                    <template v-for="item in grp.items" :key="`m-item-${item.id}`">
+                      <!-- 공정 행 (접기/펼치기) -->
+                      <div
+                        class="flex cursor-pointer items-center gap-1.5 border-b border-forena-100 bg-slate-50/40 pl-4 pr-3 transition hover:bg-forena-50/60"
+                        :style="{ height: monthlyProcessHeaderHeight() + 'px' }"
+                        @click="monthlyProcessOpen[item.id] = !monthlyProcessOpen[item.id]"
+                      >
+                        <ChevronDown
+                          v-if="monthlyProcessOpen[item.id]"
+                          class="h-3.5 w-3.5 shrink-0 text-slate-500"
+                        />
+                        <ChevronRight v-else class="h-3.5 w-3.5 shrink-0 text-slate-500" />
+                        <div class="flex min-w-0 flex-1 flex-col">
+                          <div class="flex items-center gap-1.5">
+                            <p
+                              class="truncate text-sm font-bold text-forena-900"
+                              @click.stop="onClickBaseline(item)"
+                            >
+                              {{ item.name }}
+                            </p>
+                            <span
+                              v-if="item.weightPct != null"
+                              class="rounded bg-blue-50 px-1 py-0.5 text-[9px] font-bold text-blue-700"
+                            >
+                              보할 {{ item.weightPct }}%
+                            </span>
+                          </div>
+                          <p class="truncate text-[10px] text-slate-400">
+                            <span
+                              v-if="item.milestoneDate"
+                              class="inline-flex items-center gap-1"
+                              :title="
+                                item.milestoneFromAnnual
+                                  ? '연간 실행계획 종료일을 마일스톤으로 사용'
+                                  : '기준 공정 종료일'
+                              "
+                            >
+                              <span class="inline-block h-1.5 w-1.5 rotate-45 bg-rose-500"></span>
+                              마일스톤 {{ item.milestoneDate }}
+                            </span>
+                            <span v-else class="italic text-slate-300">마일스톤 없음</span>
+                          </p>
+                        </div>
+                        <span
+                          class="rounded bg-white/70 px-1.5 py-0.5 text-[9px] tabular-nums text-slate-500"
+                          >{{ (item.details && item.details.length) || 0 }}</span
+                        >
+                      </div>
+
+                      <!-- 세부계획 행들 (공정이 펼쳐져 있을 때만) -->
+                      <template v-if="monthlyProcessOpen[item.id]">
+                        <div
+                          v-for="d in item.details"
+                          :key="`m-detail-${d.id}`"
+                          class="flex cursor-pointer items-center gap-1.5 border-b border-forena-50 pl-10 pr-3 transition hover:bg-rose-50/40"
+                          :style="{ height: monthlyDetailRowHeight() + 'px' }"
+                          @click.stop="onClickWorkPlan(d)"
+                        >
+                          <span class="shrink-0 text-[10px] text-slate-300">└</span>
+                          <p class="truncate text-[11px] text-slate-700">
+                            {{ d.name
+                            }}<span v-if="d.location" class="text-slate-400">
+                              · {{ d.location }}</span
+                            >
+                          </p>
+                        </div>
+                        <!-- 세부계획이 하나도 없을 때 안내 행 -->
+                        <div
+                          v-if="!item.details || !item.details.length"
+                          class="flex items-center border-b border-forena-50 pl-10 pr-3 text-[10px] italic text-slate-300"
+                          :style="{ height: monthlyDetailRowHeight() + 'px' }"
+                        >
+                          세부계획 없음 (월간 계획서를 업로드하세요)
+                        </div>
+                      </template>
+                    </template>
+                  </template>
+                </template>
               </div>
 
               <!-- 우측: 차트 -->
@@ -1574,78 +2343,132 @@ function selectViewMode(mode) {
                     :style="todayLineStyle"
                   ></div>
 
-                  <!-- 작업 행들 -->
-                  <div
-                    v-for="p in ganttPlans"
-                    :key="p.id"
-                    class="relative flex h-[68px] border-b border-forena-100"
-                    :class="selectedPlan?.id === p.id ? 'bg-flare-50/40' : ''"
-                  >
-                    <!-- 셀 그리드 -->
+                  <template v-for="grp in monthlyGroups" :key="`m-grow-${grp.group}`">
+                    <!-- 공종 그룹 헤더 (오른쪽 빈 영역) -->
                     <div
-                      v-for="d in monthMeta.days"
-                      :key="d.date"
-                      class="border-r border-forena-50"
-                      :style="{ width: GANTT_DAY_W + 'px' }"
-                      :class="monthlyDayCellClass(d)"
+                      class="h-9 border-b border-forena-200 bg-gradient-to-r from-forena-100 to-forena-50"
                     ></div>
 
-                    <!-- 계획 라인 (월간 작업계획서 기준) -->
-                    <div
-                      v-if="barStyle(p.start, p.end)"
-                      class="group absolute z-[2] flex cursor-pointer items-center"
-                      :style="{ ...barStyle(p.start, p.end), top: '20px', height: '4px' }"
-                      :title="`계획서 기준: ${p.start} ~ ${p.end}`"
-                      @click="selectedPlan = p"
-                    >
-                      <span
-                        class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-violet-600 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-violet-600 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="h-1 w-full rounded-full bg-violet-600 transition group-hover:h-1.5"
-                      ></span>
-                    </div>
+                    <template v-if="groupOpen[grp.group]">
+                      <template v-for="item in grp.items" :key="`m-row-${item.id}`">
+                        <!-- 공정 행: 마일스톤 마커 표시 -->
+                        <div
+                          class="relative flex border-b border-forena-100 bg-slate-50/40"
+                          :style="{ height: monthlyProcessHeaderHeight() + 'px' }"
+                        >
+                          <div
+                            v-for="d in monthMeta.days"
+                            :key="d.date"
+                            class="border-r border-forena-50"
+                            :style="{ width: GANTT_DAY_W + 'px' }"
+                            :class="monthlyDayCellClass(d)"
+                          ></div>
 
-                    <!-- 실제/예상 진행 라인: 연장 시 빨간 예상선이 연장 종료일까지 이어짐 -->
-                    <div
-                      v-if="barStyle(actualLineRange(p).start, actualLineRange(p).end)"
-                      class="absolute z-[1] flex cursor-pointer items-center"
-                      :style="{
-                        ...barStyle(actualLineRange(p).start, actualLineRange(p).end),
-                        top: '40px',
-                        height: '4px',
-                      }"
-                      :title="`실제/예상 진행: ${actualLineRange(p).start} ~ ${actualLineRange(p).end}`"
-                      @click="selectedPlan = p"
-                    >
-                      <span class="h-1 w-full rounded-full bg-green-300"></span>
-                    </div>
-                    <div
-                      v-if="
-                        progressFillEnd(p) && barStyle(actualLineRange(p).start, progressFillEnd(p))
-                      "
-                      class="group absolute z-[2] flex cursor-pointer items-center"
-                      :style="{
-                        ...barStyle(actualLineRange(p).start, progressFillEnd(p)),
-                        top: '40px',
-                        height: '4px',
-                      }"
-                      @click="selectedPlan = p"
-                    >
-                      <span
-                        class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-green-700 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-green-700 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="h-1 w-full rounded-full bg-green-700 transition group-hover:h-1.5"
-                      ></span>
-                    </div>
-                  </div>
+                          <!-- 마일스톤 마커 (마름모) -->
+                          <div
+                            v-if="item.milestoneDate && monthCellCenterStyle(item.milestoneDate)"
+                            class="absolute z-[2] flex cursor-pointer items-center justify-center"
+                            :style="{
+                              ...monthCellCenterStyle(item.milestoneDate),
+                              top: '50%',
+                              width: '14px',
+                              height: '14px',
+                              transform: 'translate(-7px, -50%)',
+                            }"
+                            :title="`마일스톤: ${item.milestoneDate}`"
+                            @click.stop="onClickBaseline(item)"
+                          >
+                            <span
+                              class="block h-2.5 w-2.5 rotate-45 bg-rose-500 ring-2 ring-white"
+                            ></span>
+                          </div>
+                        </div>
+
+                        <!-- 세부계획 행들 -->
+                        <template v-if="monthlyProcessOpen[item.id]">
+                          <div
+                            v-for="d in item.details"
+                            :key="`m-detail-row-${d.id}`"
+                            class="relative flex border-b border-forena-50"
+                            :style="{ height: monthlyDetailRowHeight() + 'px' }"
+                          >
+                            <div
+                              v-for="dd in monthMeta.days"
+                              :key="dd.date"
+                              class="border-r border-forena-50"
+                              :style="{ width: GANTT_DAY_W + 'px' }"
+                              :class="monthlyDayCellClass(dd)"
+                            ></div>
+
+                            <!-- 파란선: 월간계획서 기준 (plannedStart/plannedEnd) -->
+                            <div
+                              v-if="
+                                d.plannedStart &&
+                                d.plannedEnd &&
+                                barStyle(d.plannedStart, d.plannedEnd)
+                              "
+                              class="group absolute z-[2] flex cursor-pointer items-center"
+                              :style="{
+                                ...barStyle(d.plannedStart, d.plannedEnd),
+                                top: '8px',
+                                height: '4px',
+                              }"
+                              :title="`월간 기준: ${d.plannedStart} ~ ${d.plannedEnd}`"
+                              @click.stop="onClickWorkPlan(d)"
+                            >
+                              <span
+                                class="absolute -left-[3px] h-2 w-2 rounded-full bg-blue-600 ring-2 ring-white"
+                              ></span>
+                              <span
+                                class="absolute -right-[3px] h-2 w-2 rounded-full bg-blue-600 ring-2 ring-white"
+                              ></span>
+                              <span class="h-1 w-full rounded-full bg-blue-600"></span>
+                            </div>
+
+                            <!-- 빨간선: 실행 일정 + 진행률 -->
+                            <div
+                              v-if="barStyle(d.start, d.end)"
+                              class="group absolute z-[2] cursor-pointer"
+                              :style="{
+                                ...barStyle(d.start, d.end),
+                                top: '20px',
+                                height: '4px',
+                              }"
+                              :title="`${d.name}${d.location ? ' · ' + d.location : ''}\n실행: ${d.start} ~ ${d.end}`"
+                              @click.stop="onClickWorkPlan(d)"
+                            >
+                              <span
+                                class="absolute -left-[3px] top-1/2 z-[2] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                              ></span>
+                              <span
+                                class="absolute top-1/2 z-[2] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                                :style="progressDotStyle(d, barStyle)"
+                              ></span>
+                              <span class="absolute inset-0 z-0 rounded-full bg-red-200"></span>
+                              <span
+                                class="absolute inset-y-0 left-0 z-[1] rounded-full bg-red-500 transition group-hover:h-1.5"
+                                :style="progressBarStyle(d, barStyle)"
+                              ></span>
+                            </div>
+                          </div>
+                          <!-- 세부계획이 없을 때 빈 행 (좌측과 높이 매칭) -->
+                          <div
+                            v-if="!item.details || !item.details.length"
+                            class="relative flex border-b border-forena-50"
+                            :style="{ height: monthlyDetailRowHeight() + 'px' }"
+                          >
+                            <div
+                              v-for="dd in monthMeta.days"
+                              :key="dd.date"
+                              class="border-r border-forena-50"
+                              :style="{ width: GANTT_DAY_W + 'px' }"
+                              :class="monthlyDayCellClass(dd)"
+                            ></div>
+                          </div>
+                        </template>
+                      </template>
+                    </template>
+                  </template>
                 </div>
               </div>
             </div>
@@ -1909,6 +2732,36 @@ function selectViewMode(mode) {
             </button>
           </div>
 
+          <!-- 월간 계획 선택 -->
+          <div class="shrink-0 border-b border-forena-100 bg-white px-6 py-4">
+            <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
+              월간 계획 선택 <span class="text-rose-500">*</span>
+            </label>
+
+            <select
+              v-model="weeklyForm.monthlyPlanId"
+              @change="onSelectMonthlyPlan"
+              class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-2 text-xs outline-none focus:border-flare-400"
+            >
+              <option :value="null">월간 세부계획을 선택하세요</option>
+              <option v-for="opt in monthlyPlanOptions" :key="opt.id" :value="opt.id">
+                {{ opt.label }}
+              </option>
+            </select>
+
+            <div
+              v-if="weeklyForm.monthlyPlanId"
+              class="mt-3 rounded-lg border border-flare-100 bg-flare-50/50 px-3 py-2 text-xs text-forena-700"
+            >
+              <p class="font-bold text-forena-900">
+                {{ weeklyForm.monthlyPlanName }}
+              </p>
+              <p class="mt-1">
+                위치 {{ weeklyForm.monthlyLocation || '-' }} · 기간 {{ weeklyForm.monthlyStart }} ~
+                {{ weeklyForm.monthlyEnd }}
+              </p>
+            </div>
+          </div>
           <!-- 협력사 정보 -->
           <div
             class="grid shrink-0 grid-cols-1 gap-3 border-b border-forena-100 bg-forena-50/40 px-6 py-4 sm:grid-cols-4"
@@ -2005,17 +2858,17 @@ function selectViewMode(mode) {
                   </div>
                   <div class="lg:col-span-2">
                     <label class="mb-1 block text-[10px] font-bold text-forena-500"
-                      >공정명 <span class="text-rose-500">*</span></label
+                      >일일 작업 내용 <span class="text-rose-500">*</span></label
                     >
                     <input
                       v-model="item.processName"
-                      placeholder="예: B2층 전기 배관 설치"
+                      placeholder="예: 타설 전 거푸집 및 철근 상태 점검"
                       class="w-full rounded-md border border-forena-200 px-2 py-1.5 text-xs outline-none focus:border-flare-400"
                     />
                   </div>
                   <div class="lg:col-span-2">
                     <label class="mb-1 block text-[10px] font-bold text-forena-500"
-                      >작업구역 <span class="text-rose-500">*</span></label
+                      >세부 작업 위치 <span class="text-rose-500">*</span></label
                     >
                     <input
                       v-model="item.zone"


### PR DESCRIPTION
## :hammer_and_wrench: 작업 내용
- 공정 계획 페이지 기능 추가
- 공정 계획 API 연동
- 간트차트 표시 기능 개선
- 공정 분석 및 지연 변경 요청 API 연동

## :clipboard: 상세 내용
- 공정 계획 목록 조회 API 연동
- 연간/월간/주간 계획 데이터 조회 및 화면 표시
- 공정 기준 일정과 실행 계획 데이터를 간트차트에 표시
- 공정 분석 페이지 연동을 위한 API 추가
- 지연 발생 시 일정 변경 요청을 처리하기 위한 API 추가
- develop 병합 충돌 해결 후 최신 코드 기준으로 반영

## :white_check_mark: 테스트 내용
- 공정 계획 목록 조회 확인
- 계획 데이터 화면 표시 확인
- 간트차트 일정 표시 확인
- 분석 API 파일 추가 확인
- 일정 변경 요청 API 파일 추가 확인

## :pushpin: 참고 사항

closed #329 