### PR TITLE
[Feat] 공사일보 페이지 및 API 연동 기능 추가

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -31,7 +31,8 @@ api.interceptors.response.use(
         return Promise.reject(new Error(body.message || '요청이 실패했습니다.'))
       }
       // data 필드 반환 (없으면 body 전체)
-      return body.data !== undefined ? body.data : body
+      if (body.data !== undefined) return body.data
+      if (body.result !== undefined) return body.result
     }
 
     return body

--- a/src/api/masterSchedule.js
+++ b/src/api/masterSchedule.js
@@ -1,0 +1,33 @@
+import api from './index'
+
+export const uploadMasterSchedule = ({ projectId, docType, file }) => {
+  const formData = new FormData()
+
+  formData.append('projectId', projectId)
+  formData.append('docType', docType)
+  formData.append('file', file)
+
+  return api.post('/master-schedule/upload', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+    timeout: 60000,
+  })
+}
+
+export const getMasterScheduleList = ({ projectId, docType }) => {
+  return api.get('/master-schedule', {
+    params: {
+      projectId,
+      docType,
+    },
+  })
+}
+
+export const getMasterScheduleDetail = (scheduleId) => {
+  return api.get(`/master-schedule/${scheduleId}`)
+}
+
+export const deleteMasterSchedule = (scheduleId) => {
+  return api.delete(`/master-schedule/${scheduleId}`)
+}

--- a/src/api/tradeProcess.js
+++ b/src/api/tradeProcess.js
@@ -1,0 +1,29 @@
+import api from './index.js'
+
+const PATH = '/trade-process'
+
+const toTradeProcessPlan = (dto) => ({
+  id: `tp-${dto.idx}`,
+  tradeProcessId: dto.idx,
+  masterScheduleId: dto.masterScheduleId,
+  projectId: dto.projectId,
+
+  name: dto.processName,
+  trade: dto.tradeName,
+  partner: dto.partnerCompany || '',
+
+  start: dto.plannedStart,
+  end: dto.plannedEnd,
+
+  weightPct: dto.weightPct ?? 0,
+  isMilestone: dto.isMilestone ?? false,
+
+  planType: '기준',
+  status: '진행 예정',
+  source: 'trade_process',
+})
+
+export const fetchTradeProcessList = async (params = {}) => {
+  const dtos = await api.get(PATH, { params })
+  return Array.isArray(dtos) ? dtos.map(toTradeProcessPlan) : []
+}

--- a/src/api/workOrder.js
+++ b/src/api/workOrder.js
@@ -1,0 +1,31 @@
+import api from './index' // localAxios 대신 기본 api 인스턴스를 가져옵니다.
+
+const BASE_URL = '/work-order'
+
+// 1. 작업 지시서 작성
+export const createWorkOrder = async (workOrderData) => {
+  return await api.post(BASE_URL, workOrderData)
+}
+
+export const getWorkOrderList = async () => {
+  return await api.get(BASE_URL)
+}
+
+// 2. 작업 지시서 단일 조회
+export const getWorkOrder = async (workOrderId) => {
+  return await api.get(`${BASE_URL}/${workOrderId}`)
+}
+
+// 3. 작업 지시서 수정
+export const updateWorkOrder = async (workOrderId, workOrderData) => {
+  return await api.put(`${BASE_URL}/${workOrderId}`, workOrderData)
+}
+
+// 4. 작업 지시서 삭제
+export const deleteWorkOrder = async (workOrderId) => {
+  return await api.delete(`${BASE_URL}/${workOrderId}`)
+}
+
+export const approveWorkOrder = async (workOrderId) => {
+  return await api.put(`${BASE_URL}/${workOrderId}/approve`)
+}

--- a/src/api/workplan.js
+++ b/src/api/workplan.js
@@ -4,11 +4,9 @@ const PATH = '/work-plan'
 
 const normalizeStatus = (status) => {
   if (!status) return '진행 예정'
-
   if (status === '계획') return '진행 예정'
   if (status === '검토 중') return '진행 예정'
   if (status === '확정') return '진행 예정'
-
   return status
 }
 
@@ -29,6 +27,13 @@ const toPlan = (dto) => {
 
   return {
     id: dto.idx,
+    tradeProcessId: dto.tradeProcessId ?? dto.trade_process_id ?? dto.tradeProcess?.idx ?? null,
+
+    tradeProcessName: dto.tradeProcessName ?? dto.trade_process_name ?? null,
+    parentWorkPlanId:
+      dto.parentWorkPlanId ?? dto.parent_work_plan_id ?? dto.parentWorkPlan?.idx ?? null,
+
+    parentWorkPlanName: dto.parentWorkPlanName ?? dto.parent_work_plan_name ?? null,
     name: dto.name,
     trade: dto.trade,
     location: dto.location,
@@ -37,6 +42,9 @@ const toPlan = (dto) => {
     start: dto.startDate,
     end: dto.endDate,
     actualStart: dto.actualStart || null,
+    actualPct: dto.actualPct ?? dto.actualProgress ?? null,
+    progressPct: dto.progressPct ?? dto.progress ?? null,
+    processProgress: dto.processProgress ?? null,
     requiredCount: dto.requiredCount ?? 0,
     workers: normalizeStringList(dto.workers),
     equipment: normalizeStringList(dto.equipment),
@@ -58,11 +66,14 @@ const toPlan = (dto) => {
 
 /**
  * 프론트 plan 객체 → 백엔드 Req
- * (plan 등록/수정 시 사용)
  */
 const toReq = (plan) => ({
+  // ── 1단계 추가 ────────────────────────────────────────────────────────────
+  tradeProcessId: plan.tradeProcessId || null,
+  // ──────────────────────────────────────────────────────────────────────────
   name: plan.name,
   trade: plan.trade,
+  parentWorkPlanId: plan.parentWorkPlanId || null,
   location: plan.location,
   planType: plan.planType,
   status: normalizeStatus(plan.status),
@@ -77,10 +88,6 @@ const toReq = (plan) => ({
   workers: Array.isArray(plan.workers) ? plan.workers : [],
   equipment: Array.isArray(plan.equipment) ? plan.equipment : [],
 })
-
-// =========================================================
-// API 함수들
-// =========================================================
 
 /**
  * 작업 계획 등록

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -42,6 +42,8 @@ export const useAuthStore = defineStore('auth', () => {
       accessScope.value = ACCESS_FULL
       role.value = ROLE_SITE_MANAGER
       isAuthenticated.value = true
+      isUpload.value = false
+      persistAuth()
       return true
     }
     if (id === 'viewer' && pw === 'viewer') {
@@ -49,7 +51,8 @@ export const useAuthStore = defineStore('auth', () => {
       accessScope.value = ACCESS_SITE_DASHBOARD_ONLY
       role.value = ROLE_SITE_MANAGER
       isAuthenticated.value = true
-      isUpload.value = true
+      isUpload.value = false
+      persistAuth()
       return true
     }
     return false

--- a/src/views/schedule/DailyWorkReportView.vue
+++ b/src/views/schedule/DailyWorkReportView.vue
@@ -1,5 +1,7 @@
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+// feat : Vue Composition API 및 외부 라이브러리 임포트
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import api from '@/api/index'
 import {
   CalendarDays, ChevronLeft, ChevronRight, FileText, Plus, Save, Upload,
   Image as ImageIcon, Paperclip, X, Users, Wrench, MapPin, ClipboardList,
@@ -7,19 +9,17 @@ import {
   ShieldCheck, UserCog, Trash2, Download
 } from 'lucide-vue-next'
 
-// =========================================================
-// 권한 / 사용자 (데모용 토글)
-// =========================================================
+// feat : 사용자 권한 상수 정의
 const ROLES = {
-  MANAGER: 'site_manager',   // 현장 총 책임자
-  WORKER:  'process_owner',  // 공정별 담당자
+  MANAGER: 'site_manager',
+  WORKER:  'process_owner',
 }
-const currentRole = ref(ROLES.WORKER)
-// 공정 담당자가 책임지는 공정 (담당자 시점에서만 의미 있음)
-const myProcess = ref('철근')
 
+const currentRole = ref(ROLES.WORKER)
+const myProcess = ref('철근')
 const ALL_PROCESSES = ['토공', '골조', '철근', '전기', '설비', '마감']
 
+// feat : 공정 카테고리별 투입 가능한 중장비 목록 데이터
 const equipmentList = {
   '굴착·토공': ['굴삭기', '미니굴삭기', '백호', '드래그라인'],
   '운반': ['덤프트럭', '트럭 믹서', '트랙터', '트레일러', '스크레이퍼'],
@@ -31,9 +31,25 @@ const equipmentList = {
   '철거·특수': ['브레이커', '니블러', '크러셔', '고소작업차', 'TBM'],
 }
 
-// =========================================================
-// 날짜 네비게이션
-// =========================================================
+// 🔥 feat : 백엔드 Enum 영문명 -> 한글 장비명 완벽 번역 맵 추가
+const EQ_ENUM_MAP = {
+  'EXCAVATOR': '굴삭기', 'MINI_EXCAVATOR': '미니굴삭기', 'BACKHOE': '백호', 'DRAGLINE': '드래그라인',
+  'DUMP_TRUCK': '덤프트럭', 'TRUCK_MIXER': '트럭 믹서', 'TRACTOR': '트랙터', 'TRAILER': '트레일러', 'SCRAPER': '스크레이퍼',
+  'TOWER_CRANE': '타워크레인', 'MOBILE_CRANE': '모바일 크레인', 'CRAWLER_CRANE': '크롤러 크레인', 'FORKLIFT': '지게차', 'LIFT': '리프트',
+  'BULLDOZER': '불도저', 'MOTOR_GRADER': '모터 그레이더', 'ROLLER': '롤러', 'COMPACTOR': '콤팩터',
+  'ASPHALT_FINISHER': '아스팔트 피니셔', 'MILLING_MACHINE': '밀링 머신', 'WATER_TRUCK': '살수차', 'ROAD_CUTTER': '노면 절단기',
+  'PILE_DRIVER': '파일 드라이버', 'BORING_MACHINE': '보링머신', 'EARTH_AUGER': '어스오거', 'RCD': 'RCD',
+  'CONCRETE_PUMP': '콘크리트 펌프카', 'BATCH_PLANT': '배치 플랜트', 'VIBRATOR': '바이브레이터',
+  'BREAKER': '브레이커', 'NIBBLER': '니블러', 'CRUSHER': '크러셔', 'AERIAL_WORK_PLATFORM': '고소작업차', 'TBM': 'TBM'
+}
+
+function getEqKorName(name) {
+  if (!name) return '장비';
+  const upperName = name.toUpperCase();
+  return EQ_ENUM_MAP[upperName] || name;
+}
+
+// feat : 날짜 처리 유틸리티 함수
 function todayStr() { return new Date().toISOString().slice(0, 10) }
 function addDays(dateStr, n) {
   const d = new Date(dateStr); d.setDate(d.getDate() + n)
@@ -53,75 +69,59 @@ function nextDay() { selectedDate.value = addDays(selectedDate.value, 1) }
 function goToday() { selectedDate.value = todayStr() }
 const isToday = computed(() => selectedDate.value === todayStr())
 
-// =========================================================
-// 본문 탭
-// =========================================================
-const activeTab = ref('today') // 'today' | 'tomorrow' | 'consolidated'
-const modalTab = ref('today') // 'today' | 'tomorrow' (모달 내 탭)
+const activeTab = ref('today')
+const modalTab = ref('today')
 
-// 책임자가 아닐 때 종합 탭에 있으면 today로 강제 이동
 function switchTab(tab) {
   if (tab === 'consolidated' && currentRole.value !== ROLES.MANAGER) return
   activeTab.value = tab
 }
 
-// =========================================================
-// 공사일보 데이터 (데모)
-// =========================================================
-// 상태: '작성 전' | '임시 저장' | '제출 완료' | '검토 중' | '승인 완료' | '반려'
-// 완료 여부: '완료' | '미완료'
-const reports = ref([
-  {
-    id: 'r_1', date: todayStr(), process: '토공',
-    author: '김토공', location: 'B3층 동측 굴착 구역',
-    workers: 14, equipmentCount: 3,
-    equipmentList: ['굴삭기 1대', '덤프트럭 2대'],
-    todayWork: '동측 토사 반출 80% 진행, 흙막이 변위 점검 완료',
-    tomorrowPlan: '잔여 토사 반출 마무리, 굴착 바닥 정리',
-    progress: 80, processProgress: 45, completion: '미완료',
-    notes: '오후 강우 예보로 오전 집중 작업 예정',
-    photos: [], files: [],
-    status: '제출 완료', submittedAt: '2026-04-29 17:20',
-  },
-  {
-    id: 'r_2', date: todayStr(), process: '골조',
-    author: '박골조', location: '지상 4층 동·서측',
-    workers: 22, equipmentCount: 2,
-    equipmentList: ['타워크레인 1대', '콘크리트 펌프카 1대'],
-    todayWork: '4층 슬라브 콘크리트 타설 완료 (320㎥)',
-    tomorrowPlan: '4층 양생 관리, 5층 거푸집 시작',
-    progress: 100, processProgress: 68, completion: '완료',
-    notes: '타설 후 시험체 6개 채취 완료',
-    photos: [], files: [],
-    status: '승인 완료', submittedAt: '2026-04-29 16:45',
-  },
-  {
-    id: 'r_3', date: todayStr(), process: '철근',
-    author: '이철근', location: '본동 3층 슬라브',
-    workers: 12, equipmentCount: 1,
-    equipmentList: ['철근 절곡기 1대'],
-    todayWork: '3층 슬라브 상부 철근 배근 70% 진행',
-    tomorrowPlan: '3층 슬라브 상부 철근 배근 마무리, 검측 요청',
-    progress: 70, processProgress: 52, completion: '미완료',
-    notes: '',
-    photos: [], files: [],
-    status: '임시 저장', submittedAt: null,
-  },
-  {
-    id: 'r_4', date: todayStr(), process: '전기',
-    author: '최전기', location: 'B2층 전기실',
-    workers: 6, equipmentCount: 1,
-    equipmentList: ['고소작업대 1대'],
-    todayWork: 'B2층 전기 배관 설치 60% 진행',
-    tomorrowPlan: 'B2층 잔여 배관 설치, 배관 청소',
-    progress: 60, processProgress: 38, completion: '미완료',
-    notes: '천장 간섭 구간 1개소 협의 필요',
-    photos: [], files: [],
-    status: '제출 완료', submittedAt: '2026-04-29 17:05',
-  },
-  // 설비 / 마감 미제출 (현장 총 책임자가 미제출 확인용)
-  // → reports 배열에 없음 = 작성 전
-])
+const reports = ref([]);
+
+// feat : 특정 일자의 공사일보 데이터를 조회
+async function loadReportsForDate(targetDate) {
+  try {
+    const res = await api.get('/report/', { params: { date: targetDate } });
+    const dbReports = Array.isArray(res) ? res : (res.data?.data || res.data || []);
+
+    const toDateString = (dateVal) => {
+      if (Array.isArray(dateVal)) {
+        return `${dateVal[0]}-${String(dateVal[1]).padStart(2, '0')}-${String(dateVal[2]).padStart(2, '0')}`;
+      }
+      return dateVal;
+    };
+
+    reports.value = dbReports.map(db => ({
+      id: db.idx,
+      workPlanId: db.workPlanId,
+      date: toDateString(db.reportDate),
+      process: db.tradeType || db.process || '공정',
+      workers: db.actualWorkerCount || 0,
+      equipmentCount: 0,
+      equipmentList: [],
+      todayWork: db.todayWork || '',
+      tomorrowPlan: db.tomorrowPlan || '',
+      progress: db.todayProgress || 0, 
+      processProgress: db.actualProgress || 0,
+      notes: db.issue || '',
+      completion: (db.actualProgress >= 100) ? '완료' : '미완료',
+      status: '제출 완료',
+      _placeholder: false
+    }));
+  } catch (error) {
+    console.error("데이터 로드 실패:", error);
+  }
+}
+
+onMounted(() => {
+  loadReportsForDate(selectedDate.value);
+  document.addEventListener('keydown', onKeydown);
+});
+
+watch(selectedDate, (newDate) => {
+  loadReportsForDate(newDate);
+});
 
 const STATUS_META = {
   '작성 전':   { cls: 'bg-slate-100 text-slate-500 ring-slate-200',         icon: Clock },
@@ -131,17 +131,14 @@ const STATUS_META = {
   '승인 완료': { cls: 'bg-emerald-50 text-emerald-700 ring-emerald-200',    icon: CheckCircle2 },
   '반려':      { cls: 'bg-rose-50 text-rose-700 ring-rose-200',             icon: AlertTriangle },
 }
+
 function statusMeta(s) { return STATUS_META[s] || STATUS_META['작성 전'] }
 
-// =========================================================
-// 권한별로 보이는 공정 / 보고서
-// =========================================================
 const visibleProcesses = computed(() => {
   if (currentRole.value === ROLES.WORKER) return [myProcess.value]
   return ALL_PROCESSES
 })
 
-// 선택된 날짜 + 가시 공정 기준 보고서. 없는 공정은 "작성 전" placeholder 생성
 function reportsForDate(dateStr) {
   return visibleProcesses.value.map(proc => {
     const found = reports.value.find(r => r.date === dateStr && r.process === proc)
@@ -162,7 +159,6 @@ function reportsForDate(dateStr) {
 const todayReports = computed(() => reportsForDate(selectedDate.value))
 const tomorrowReports = computed(() => reportsForDate(tomorrowDate.value))
 
-// 책임자 대시보드 통계
 const stats = computed(() => {
   const list = todayReports.value
   const total = list.length
@@ -171,62 +167,180 @@ const stats = computed(() => {
   const completed = list.filter(r => r.completion === '완료' && !r._placeholder).length
   const totalWorkers = list.reduce((s, r) => s + (r.workers || 0), 0)
   const totalEquip = list.reduce((s, r) => s + (r.equipmentCount || 0), 0)
-  const avgProgress = total ? Math.round(list.reduce((s, r) => s + (r.progress || 0), 0) / total) : 0
+  const avgProgress = total ? Math.round(list.reduce((s, r) => s + (r.processProgress || 0), 0) / total) : 0
   return { total, submitted, pending, completed, totalWorkers, totalEquip, avgProgress }
 })
 
-// =========================================================
-// 작성/수정 모달
-// =========================================================
 const showEditor = ref(false)
-const editingReport = ref(null) // 편집 중인 보고서 (drafts)
+const editingReport = ref(null)
 const isNewReport = ref(false)
 
 function canEdit(report) {
-  if (currentRole.value === ROLES.MANAGER) return false // 책임자는 조회만
+  if (currentRole.value === ROLES.MANAGER) return false
   if (report.process !== myProcess.value) return false
-  // 승인 완료된 건 수정 불가
   if (report.status === '승인 완료') return false
   return true
 }
 
-function openEditor(report) {
-  // placeholder면 신규로 시작
-  if (report._placeholder) {
-    isNewReport.value = true
-    editingReport.value = {
-      id: `r_${Date.now()}`,
-      date: report.date,
-      process: report.process,
-      author: '나(담당자)',
-      location: '',
-      workers: 0,
-      equipmentCount: 0,
-      equipmentList: [],
-      equipmentInput: '',
-      todayWork: '',
-      tomorrowPlan: '',
-      progress: 0,
-      processProgress: 0,
-      completion: '미완료',
-      notes: '',
-      photos: [],
-      files: [],
-      status: '작성 전',
-      submittedAt: null,
-    }
-  } else {
-    isNewReport.value = false
-    // deep clone (사진/파일은 참조 유지하지 않도록 복제)
-    editingReport.value = {
-      ...report,
-      equipmentList: [...(report.equipmentList || [])],
-      equipmentInput: '',
-      photos: (report.photos || []).map(p => ({ ...p })),
-      files: (report.files || []).map(f => ({ ...f })),
+// =========================================================
+// feat : 작성/수정 모달 오픈 및 데이터 연동 핵심 로직 (진척률 누적 버그 완벽 픽스)
+// =========================================================
+async function openEditor(report) {
+  let fetchedPrevProgress = 0;
+
+  // 이전 누적 진척률 자동 조회 (최대 3일 전까지 탐색하여 주말/휴일 커버)
+  for (let i = 1; i <= 3; i++) {
+    try {
+      const pDate = addDays(report.date, -i);
+      const pRes = await api.get('/report/', { params: { date: pDate } });
+      const pArr = Array.isArray(pRes) ? pRes : (pRes.data?.data || pRes.data || []);
+      const pTarget = pArr.find(r => r.tradeType === report.process || r.process === report.process);
+      
+      if (pTarget && pTarget.actualProgress) {
+        fetchedPrevProgress = pTarget.actualProgress;
+        break; // 이전 누적 진척률을 찾으면 즉시 탐색 종료
+      }
+    } catch (e) {
+      console.warn(`${i}일 전 진척률 조회 실패, 이전 날짜 탐색 계속...`);
     }
   }
-  showEditor.value = true
+
+  if (report._placeholder) {
+    isNewReport.value = true;
+    editingReport.value = {
+      id: `r_${Date.now()}`, date: report.date, process: report.process,
+      author: '나(담당자)', location: '', workers: 0, equipmentCount: 0,
+      equipmentList: [], equipmentInput: { name: '', count: 1 }, 
+      tomorrowWorkers: 0, tomorrowEquipmentList: [], tomorrowEquipmentInput: { name: '', count: 1 },
+      todayWork: '', tomorrowPlan: '', startDate: '', endDate: '',
+      
+      // 누적값을 넣어줍니다.
+      prevProgress: fetchedPrevProgress, 
+      progress: 0, 
+      processProgress: fetchedPrevProgress, // 모달 열었을 때 시작점도 이전 누적값으로 세팅
+      
+      completion: '미완료', notes: '', photos: [], files: [], status: '작성 전', submittedAt: null,
+      workPlanId: null,
+    };
+  } else {
+    isNewReport.value = false;
+    editingReport.value = {
+      ...report, 
+      workPlanId: report.workPlanId,
+      equipmentList: [...(report.equipmentList || [])],
+      equipmentInput: { name: '', count: 1 },
+      tomorrowWorkers: 0, tomorrowEquipmentList: [], tomorrowEquipmentInput: { name: '', count: 1 },
+      
+      // 실제 DB에서 찾아온 이전 누적값 대입
+      prevProgress: fetchedPrevProgress, 
+      progress: report.progress || 0, 
+      processProgress: report.processProgress || 0,
+      
+      photos: (report.photos || []).map(p => ({ ...p })),
+      files: (report.files || []).map(f => ({ ...f }))
+    };
+  }
+
+  try {
+    const toDateString = (dateVal) => {
+      if (!dateVal) return '';
+      if (Array.isArray(dateVal)) return `${dateVal[0]}-${String(dateVal[1]).padStart(2, '0')}-${String(dateVal[2]).padStart(2, '0')}`;
+      return dateVal;
+    };
+
+    let targetPlan = null;
+
+    if (!isNewReport.value && editingReport.value.workPlanId) {
+        try {
+            const pRes = await api.get(`/work-plan/${editingReport.value.workPlanId}`);
+            targetPlan = pRes.data?.data || pRes.data;
+        } catch (e) {
+            console.error("기존 주간계획 호출 실패:", e);
+        }
+    }
+
+    if (!targetPlan) {
+        const [weekRes, monthRes, yearRes] = await Promise.all([
+          api.get('/work-plan', { params: { planType: '주간' } }).catch(() => ({ data: [] })),
+          api.get('/work-plan', { params: { planType: '월간' } }).catch(() => ({ data: [] })),
+          api.get('/work-plan', { params: { planType: '연간' } }).catch(() => ({ data: [] }))
+        ]);
+
+        const allPlans = [
+          ...(Array.isArray(weekRes) ? weekRes : (weekRes.data?.data || weekRes.data || [])),
+          ...(Array.isArray(monthRes) ? monthRes : (monthRes.data?.data || monthRes.data || [])),
+          ...(Array.isArray(yearRes) ? yearRes : (yearRes.data?.data || yearRes.data || []))
+        ];
+
+        const tradePlans = allPlans.filter(p => {
+          const isSameTrade = (p.trade === report.process || p.tradeType === report.process);
+          const isNotDummyHack = !(p.name || '').includes('(명일 예정)'); 
+          return isSameTrade && isNotDummyHack && p.startDate && p.endDate;
+        });
+
+        if (tradePlans.length > 0) {
+          let minStart = toDateString(tradePlans[0].startDate);
+          let maxEnd = toDateString(tradePlans[0].endDate);
+          let targetWorkPlanId = tradePlans[0].idx || tradePlans[0].id;
+
+          tradePlans.forEach(p => {
+            const startStr = toDateString(p.startDate);
+            const endStr = toDateString(p.endDate);
+            if (startStr < minStart) minStart = startStr;
+            if (endStr > maxEnd) { maxEnd = endStr; targetWorkPlanId = p.idx || p.id; }
+          });
+
+          editingReport.value.startDate = minStart;
+          editingReport.value.endDate = maxEnd;
+          editingReport.value.workPlanId = targetWorkPlanId;
+
+          const coveringPlan = tradePlans.find(p => report.date >= toDateString(p.startDate) && report.date <= toDateString(p.endDate));
+          if (coveringPlan && !editingReport.value.location) {
+             editingReport.value.location = coveringPlan.location || '';
+          }
+        }
+    }
+
+    // feat : 신규 작성 시 작업지시서(WorkOrder) 데이터 병합 로직
+    if (isNewReport.value) {
+      const orderRes = await api.get('/work-order').catch(() => ({ data: [] }));
+      const orders = Array.isArray(orderRes) ? orderRes : (orderRes.data?.data || orderRes.data || []);
+      const targetOrder = orders.find(o => (o.tradeType === report.process || o.trade === report.process) && toDateString(o.dueDate) === report.date);
+
+      if (targetOrder) {
+        if (confirm(`오늘(${report.date}) 작성된 [${report.process}] 관련 지시서가 있습니다! 데이터를 불러올까요?`)) {
+          
+          // 🔥 핵심 버그 수정: 지시서에 명확한 '작업 위치'가 있고 '-'가 아니면, 계획표의 빈 위치를 무시하고 무조건 덮어씀!
+          if (targetOrder.location && targetOrder.location !== '-') {
+             editingReport.value.location = targetOrder.location;
+          }
+
+          editingReport.value.workers = targetOrder.workerCount || 0;
+          editingReport.value.todayWork = `[지시내용]\n${targetOrder.instructionContent || ''}\n\n[실제 완료]\n`;
+          
+          const eqList = [];
+          let eqCount = 0;
+          if (targetOrder.equipments && targetOrder.equipments.length > 0) {
+            targetOrder.equipments.forEach(eq => {
+              // 🔥 핵심 버그 수정: Enum 영문명을 한국어 장비명으로 번역!
+              const korName = getEqKorName(eq.equipmentName || eq.type);
+              const cnt = eq.equipmentCount || eq.count || 1;
+              eqList.push(`${korName} ${cnt}대`);
+              eqCount += cnt;
+            });
+          }
+          
+          // 🔥 중복 장비 제거 필터링 추가
+          editingReport.value.equipmentList = [...new Set(eqList)];
+          editingReport.value.equipmentCount = eqCount;
+        }
+      }
+    }
+  } catch (error) {
+    console.error("계획 연동 실패:", error);
+  }
+
+  showEditor.value = true;
 }
 
 function closeEditor() {
@@ -235,19 +349,71 @@ function closeEditor() {
   modalTab.value = 'today'
 }
 
+// feat : 공정 기간 비례 금일 증가분(%) 자동 계산 로직
+const calcInfo = computed(() => {
+  const r = editingReport.value
+  if (!r || !r.startDate || !r.endDate) return null
+  const start = new Date(r.startDate)
+  const end = new Date(r.endDate)
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) return null
+  
+  const duration = Math.max(1, Math.round((end - start) / 86400000) + 1)
+  const dailyAllocation = 100 / duration 
+  const increment = ((r.progress || 0) / 100) * dailyAllocation 
+  
+  return {
+    duration,
+    dailyAllocation: parseFloat(dailyAllocation.toFixed(2)),
+    increment: parseFloat(increment.toFixed(2)),
+  }
+})
+
+watch(
+  () => [
+    editingReport.value?.progress,
+    editingReport.value?.startDate,
+    editingReport.value?.endDate,
+    editingReport.value?.prevProgress,
+  ],
+  () => {
+    const r = editingReport.value
+    if (!r) return
+    const info = calcInfo.value
+    if (!info) {
+      r.processProgress = r.prevProgress || 0
+      return
+    }
+    r.processProgress = parseFloat(
+      Math.min(100, (r.prevProgress || 0) + info.increment).toFixed(1)
+    )
+  },
+  { deep: true }
+)
+
 function addEquipment() {
-  const v = (editingReport.value.equipmentInput || '').trim()
+  const v = (editingReport.value.equipmentInput.name || '').trim()
   if (!v) return
-  editingReport.value.equipmentList.push(v)
-  editingReport.value.equipmentInput = ''
+  const count = Math.max(1, editingReport.value.equipmentInput.count || 1)
+  editingReport.value.equipmentList.push(v + ' ' + count + '대')
+  editingReport.value.equipmentInput = { name: '', count: 1 }
 }
+
 function removeEquipment(idx) {
   editingReport.value.equipmentList.splice(idx, 1)
 }
 
-// =========================================================
-// 사진 / 파일 업로드 (FileReader 미리보기)
-// =========================================================
+function addTomorrowEquipment() {
+  const v = (editingReport.value.tomorrowEquipmentInput.name || '').trim()
+  if (!v) return
+  const count = Math.max(1, editingReport.value.tomorrowEquipmentInput.count || 1)
+  editingReport.value.tomorrowEquipmentList.push(v + ' ' + count + '대')
+  editingReport.value.tomorrowEquipmentInput = { name: '', count: 1 }
+}
+
+function removeTomorrowEquipment(idx) {
+  editingReport.value.tomorrowEquipmentList.splice(idx, 1)
+}
+
 const photoInputRef = ref(null)
 const fileInputRef = ref(null)
 
@@ -262,9 +428,7 @@ function onPhotoChange(e) {
     reader.onload = (ev) => {
       editingReport.value.photos.push({
         id: `p_${Date.now()}_${Math.random().toString(36).slice(2,6)}`,
-        name: f.name,
-        size: f.size,
-        dataUrl: ev.target.result,
+        name: f.name, size: f.size, dataUrl: ev.target.result,
       })
     }
     reader.readAsDataURL(f)
@@ -277,9 +441,7 @@ function onFileChangeInput(e) {
   list.forEach(f => {
     editingReport.value.files.push({
       id: `f_${Date.now()}_${Math.random().toString(36).slice(2,6)}`,
-      name: f.name,
-      size: f.size,
-      type: f.type,
+      name: f.name, size: f.size, type: f.type,
     })
   })
   e.target.value = ''
@@ -301,36 +463,66 @@ function fileBadge(type) {
   return '파일'
 }
 
-// =========================================================
-// 임시저장 / 제출
-// =========================================================
 function saveDraft() {
   persistEditing('임시 저장')
   closeEditor()
 }
-function submitReport() {
-  // 필수 검증
+
+async function submitReport() {
   const r = editingReport.value
-  if (!r.location.trim()) {
-    alert('작업 위치는 필수입니다.')
-    return
+  
+  if (!r.location.trim()) { alert('작업 위치는 필수입니다.'); return; }
+  if (!r.todayWork.trim()) { alert('금일 작업 완료 내용은 필수입니다.'); return; }
+  if (!r.tomorrowPlan.trim()) { alert('명일 작업 예정은 필수입니다.'); return; }
+
+  if (!r.workPlanId) {
+    alert(`DB에 [${r.process}] 공정의 전체 계획을 찾지 못해 보고서를 제출할 수 없습니다 ㅠㅠ (공정 기간이 세팅되었는지 확인해주세요)`);
+    return;
   }
-  if (!r.todayWork.trim()) {
-    alert('금일 작업 완료 내용은 필수입니다.')
-    return
+
+  try {
+    const payload = {
+      workPlanId: r.workPlanId,                           
+      todayProgress: parseFloat(r.progress || 0),         
+      actualProgress: parseFloat(r.processProgress || 0), 
+      actualWorkerCount: r.workers || 0,                  
+      issue: r.notes || '특이사항 없음',                  
+      reportDate: r.date,                                 
+      todayWork: r.todayWork,                             
+      tomorrowPlan: r.tomorrowPlan,                       
+      
+      tomorrowWorkerCount: r.tomorrowWorkers || 0,
+      tomorrowEquipments: r.tomorrowEquipmentList.map(eqStr => {
+         // 한글 장비명을 역으로 영문 Enum으로 바꾸는 과정은 서버 로직에 맞춰 필요 시 추가
+         // 현재 백엔드에서는 라벨명 매칭을 처리하도록 되어있으므로 텍스트 그대로 전송
+         const match = eqStr.match(/(.+)\s+(\d+)대/);
+         if (match) {
+             return { type: match[1].trim(), count: parseInt(match[2], 10) };
+         }
+         return { type: '기타', count: 1 };
+      })
+    };
+
+    await api.post('/report/', payload);
+
+    r.submittedAt = new Date().toISOString().slice(0, 16).replace('T', ' ')
+    persistEditing('제출 완료')
+    closeEditor()
+
+    alert('🎉 공사일보 제출 및 내일 작업계획(WorkPlan) 업데이트가 완료되었습니다!');
+    
+    loadReportsForDate(selectedDate.value);
+
+  } catch (error) {
+    console.error(error);
+    alert('공사일보 제출에 실패했습니다. (콘솔 로그를 확인해 주세요)');
   }
-  if (!r.tomorrowPlan.trim()) {
-    alert('명일 작업 예정은 필수입니다.')
-    return
-  }
-  r.submittedAt = new Date().toISOString().slice(0, 16).replace('T', ' ')
-  persistEditing('제출 완료')
-  closeEditor()
 }
 
 function persistEditing(newStatus) {
   const r = editingReport.value
   delete r.equipmentInput
+  delete r.tomorrowEquipmentInput
   r.status = newStatus
 
   const idx = reports.value.findIndex(x => x.id === r.id)
@@ -338,17 +530,15 @@ function persistEditing(newStatus) {
   else reports.value.push({ ...r })
 }
 
-// =========================================================
-// 책임자: 보고서 상세 보기 (조회 전용)
-// =========================================================
 const viewingReport = ref(null)
+
 function openViewer(report) {
   if (report._placeholder) return
   viewingReport.value = report
 }
+
 function closeViewer() { viewingReport.value = null }
 
-// 책임자 액션 (승인 / 반려 / 검토)
 function approveReport() {
   if (!viewingReport.value) return
   const idx = reports.value.findIndex(r => r.id === viewingReport.value.id)
@@ -357,6 +547,7 @@ function approveReport() {
     viewingReport.value = reports.value[idx]
   }
 }
+
 function rejectReport() {
   if (!viewingReport.value) return
   const idx = reports.value.findIndex(r => r.id === viewingReport.value.id)
@@ -366,13 +557,12 @@ function rejectReport() {
   }
 }
 
-// ESC 닫기
 function onKeydown(e) {
   if (e.key !== 'Escape') return
   if (showEditor.value) closeEditor()
   else if (viewingReport.value) closeViewer()
 }
-onMounted(() => document.addEventListener('keydown', onKeydown))
+
 onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
 </script>
 
@@ -387,7 +577,6 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
       </div>
 
       <div class="flex flex-wrap items-center gap-2">
-        <!-- 권한 토글 (데모) -->
         <div class="flex overflow-hidden rounded-lg border border-forena-200 bg-white">
           <button
             class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold transition"
@@ -403,7 +592,6 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
           </button>
         </div>
 
-        <!-- 담당자일 때만 담당 공정 셀렉트 -->
         <select v-if="currentRole === ROLES.WORKER" v-model="myProcess"
           class="rounded-lg border border-forena-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-forena-700 outline-none focus:border-flare-400">
           <option v-for="p in ALL_PROCESSES" :key="p" :value="p">{{ p }} 공정</option>
@@ -437,47 +625,30 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
       </div>
 
       <div class="flex items-center gap-1">
-        <button @click="prevDay"
-          class="flex h-7 w-7 items-center justify-center rounded-md border border-forena-200 bg-white text-forena-600 hover:bg-forena-50">
+        <button @click="prevDay" class="flex h-7 w-7 items-center justify-center rounded-md border border-forena-200 bg-white text-forena-600 hover:bg-forena-50">
           <ChevronLeft class="h-3.5 w-3.5" />
         </button>
-        <input type="date" v-model="selectedDate"
-          class="rounded-md border border-forena-200 bg-white px-2 py-1 text-xs font-semibold tabular-nums text-forena-800 outline-none focus:border-flare-400" />
-        <button @click="nextDay"
-          class="flex h-7 w-7 items-center justify-center rounded-md border border-forena-200 bg-white text-forena-600 hover:bg-forena-50">
+        <input type="date" v-model="selectedDate" class="rounded-md border border-forena-200 bg-white px-2 py-1 text-xs font-semibold tabular-nums text-forena-800 outline-none focus:border-flare-400" />
+        <button @click="nextDay" class="flex h-7 w-7 items-center justify-center rounded-md border border-forena-200 bg-white text-forena-600 hover:bg-forena-50">
           <ChevronRight class="h-3.5 w-3.5" />
         </button>
-        <button @click="goToday"
-          class="ml-1 rounded-md border px-2 py-1 text-[10px] font-bold transition"
-          :class="isToday ? 'border-flare-200 bg-flare-50 text-flare-700' : 'border-forena-200 bg-white text-forena-600 hover:bg-forena-50'"
-          :disabled="isToday">
-          오늘
-        </button>
+        <button @click="goToday" class="ml-1 rounded-md border px-2 py-1 text-[10px] font-bold transition" :class="isToday ? 'border-flare-200 bg-flare-50 text-flare-700' : 'border-forena-200 bg-white text-forena-600 hover:bg-forena-50'" :disabled="isToday">오늘</button>
       </div>
 
       <span class="text-xs font-semibold text-forena-700 tabular-nums">{{ fmtKor(selectedDate) }}</span>
 
       <div class="ml-auto flex items-center gap-2">
-        <!-- 책임자 전용: 미제출 알림 -->
-        <span v-if="currentRole === ROLES.MANAGER && stats.pending > 0"
-          class="inline-flex items-center gap-1.5 rounded-md bg-rose-50 px-2.5 py-1 text-[11px] font-bold text-rose-700 ring-1 ring-rose-200">
-          <AlertTriangle class="h-3 w-3" />
-          미제출 {{ stats.pending }}건
+        <span v-if="currentRole === ROLES.MANAGER && stats.pending > 0" class="inline-flex items-center gap-1.5 rounded-md bg-rose-50 px-2.5 py-1 text-[11px] font-bold text-rose-700 ring-1 ring-rose-200">
+          <AlertTriangle class="h-3 w-3" />미제출 {{ stats.pending }}건
         </span>
-
-        <!-- 담당자 전용: 작성/수정 버튼 -->
-        <button v-if="currentRole === ROLES.WORKER"
-          @click="openEditor(reportsForDate(selectedDate)[0])"
-          class="inline-flex items-center gap-1.5 rounded-lg bg-flare-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm hover:bg-flare-600">
-          <Plus class="h-3.5 w-3.5" />
-          {{ reportsForDate(selectedDate)[0]?._placeholder ? '공사일보 작성' : '공사일보 수정' }}
+        <button v-if="currentRole === ROLES.WORKER" @click="openEditor(reportsForDate(selectedDate)[0])" class="inline-flex items-center gap-1.5 rounded-lg bg-flare-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm hover:bg-flare-600">
+          <Plus class="h-3.5 w-3.5" />{{ reportsForDate(selectedDate)[0]?._placeholder ? '공사일보 작성' : '공사일보 수정' }}
         </button>
       </div>
     </div>
 
-    <!-- ========== 책임자 전용: 요약 통계 ========== -->
-    <div v-if="currentRole === ROLES.MANAGER"
-      class="grid shrink-0 grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6">
+    <!-- ========== 통계 및 탭 바 ========== -->
+    <div v-if="currentRole === ROLES.MANAGER" class="grid shrink-0 grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6">
       <div class="rounded-xl border border-forena-100 bg-white p-3.5">
         <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">전체 공정</p>
         <p class="mt-1 text-2xl font-bold tabular-nums text-forena-900">{{ stats.total }}</p>
@@ -491,15 +662,11 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
         <p class="mt-1 text-2xl font-bold tabular-nums text-rose-700">{{ stats.pending }}</p>
       </div>
       <div class="rounded-xl border border-forena-100 bg-white p-3.5">
-        <p class="flex items-center gap-1 text-[10px] font-bold uppercase tracking-wide text-forena-400">
-          <Users class="h-3 w-3" /> 총 투입 인력
-        </p>
+        <p class="flex items-center gap-1 text-[10px] font-bold uppercase tracking-wide text-forena-400"><Users class="h-3 w-3" /> 총 투입 인력</p>
         <p class="mt-1 text-2xl font-bold tabular-nums text-forena-900">{{ stats.totalWorkers }}<span class="text-sm font-normal text-slate-400 ml-1">명</span></p>
       </div>
       <div class="rounded-xl border border-forena-100 bg-white p-3.5">
-        <p class="flex items-center gap-1 text-[10px] font-bold uppercase tracking-wide text-forena-400">
-          <Wrench class="h-3 w-3" /> 총 투입 장비
-        </p>
+        <p class="flex items-center gap-1 text-[10px] font-bold uppercase tracking-wide text-forena-400"><Wrench class="h-3 w-3" /> 총 투입 장비</p>
         <p class="mt-1 text-2xl font-bold tabular-nums text-forena-900">{{ stats.totalEquip }}<span class="text-sm font-normal text-slate-400 ml-1">대</span></p>
       </div>
       <div class="rounded-xl border border-flare-100 bg-flare-50/40 p-3.5">
@@ -508,218 +675,74 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
       </div>
     </div>
 
-    <!-- ========== 탭 바 ========== -->
-    <div class="flex shrink-0 items-center gap-1 border-b border-forena-100">
-      <button
-        class="border-b-2 px-4 py-2 text-xs font-bold transition"
-        :class="activeTab === 'today' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'"
-        @click="switchTab('today')">
-        금일 공사일보
-      </button>
-      <button
-        class="border-b-2 px-4 py-2 text-xs font-bold transition"
-        :class="activeTab === 'tomorrow' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'"
-        @click="switchTab('tomorrow')">
-        명일 작업 예정
-      </button>
-      <button v-if="currentRole === ROLES.MANAGER"
-        class="inline-flex items-center gap-1.5 border-b-2 px-4 py-2 text-xs font-bold transition"
-        :class="activeTab === 'consolidated' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'"
-        @click="switchTab('consolidated')">
-        <Layers class="h-3.5 w-3.5" /> 종합 공사일보
-      </button>
+    <!-- feat : 메인 화면 탭 내비게이션 -->
+    <div class="flex shrink-0 items-center gap-1 border-b border-forena-100 mt-2">
+      <button class="border-b-2 px-4 py-2 text-xs font-bold transition" :class="activeTab === 'today' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'" @click="switchTab('today')">금일 공사일보</button>
+      <button class="border-b-2 px-4 py-2 text-xs font-bold transition" :class="activeTab === 'tomorrow' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'" @click="switchTab('tomorrow')">명일 작업 예정</button>
+      <button v-if="currentRole === ROLES.MANAGER" class="inline-flex items-center gap-1.5 border-b-2 px-4 py-2 text-xs font-bold transition" :class="activeTab === 'consolidated' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'" @click="switchTab('consolidated')"><Layers class="h-3.5 w-3.5" /> 종합 공사일보</button>
     </div>
 
     <!-- ========== 본문 ========== -->
     <div class="min-h-0 flex-1 overflow-y-auto">
-
-      <!-- ============ 금일 공사일보 ============ -->
-      <div v-if="activeTab === 'today'" class="grid grid-cols-1 gap-3 lg:grid-cols-2">
-        <div v-for="r in todayReports" :key="r.id"
-          class="flex flex-col rounded-xl border bg-white transition"
-          :class="r._placeholder ? 'border-dashed border-forena-200' : 'border-forena-100 hover:border-flare-200 hover:shadow-sm'">
-
-          <!-- 카드 헤더 -->
+      
+      <!-- ============ 금일 공사일보 탭 영역 ============ -->
+      <div v-if="activeTab === 'today'" class="grid grid-cols-1 gap-3 lg:grid-cols-2 mt-2">
+        <div v-for="r in todayReports" :key="r.id" class="flex flex-col rounded-xl border bg-white transition" :class="r._placeholder ? 'border-dashed border-forena-200' : 'border-forena-100 hover:border-flare-200 hover:shadow-sm'">
+          
           <div class="flex items-start justify-between gap-3 border-b border-forena-100 px-4 py-3">
             <div class="min-w-0">
               <div class="flex items-center gap-1.5">
                 <span class="rounded-md bg-forena-50 px-1.5 py-0.5 text-[10px] font-bold text-forena-700">{{ r.process }} 공정</span>
-                <span class="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-bold ring-1"
-                  :class="statusMeta(r.status).cls">
-                  <component :is="statusMeta(r.status).icon" class="h-3 w-3" />
-                  {{ r.status }}
-                </span>
-                <span v-if="!r._placeholder" class="rounded-md px-1.5 py-0.5 text-[10px] font-bold ring-1"
-                  :class="r.completion === '완료' ? 'bg-emerald-50 text-emerald-700 ring-emerald-200' : 'bg-amber-50 text-amber-700 ring-amber-200'">
-                  {{ r.completion }}
-                </span>
+                <span class="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-bold ring-1" :class="statusMeta(r.status).cls"><component :is="statusMeta(r.status).icon" class="h-3 w-3" /> {{ r.status }}</span>
               </div>
               <p class="mt-1.5 truncate text-sm font-bold text-forena-900">{{ r.location || '작업 위치 미입력' }}</p>
-              <p class="mt-0.5 text-[11px] text-forena-400">
-                작성자 {{ r.author }}<span v-if="r.submittedAt"> · 제출 {{ r.submittedAt }}</span>
-              </p>
             </div>
             <div class="flex shrink-0 gap-1">
-              <button v-if="!r._placeholder" @click="openViewer(r)"
-                class="rounded-md border border-forena-200 bg-white p-1.5 text-forena-600 hover:bg-forena-50" title="상세 보기">
-                <Eye class="h-3.5 w-3.5" />
-              </button>
-              <button v-if="canEdit(r)" @click="openEditor(r)"
-                class="rounded-md border border-flare-200 bg-flare-50 p-1.5 text-flare-700 hover:bg-flare-100" title="수정">
-                <Pencil class="h-3.5 w-3.5" />
-              </button>
-              <button v-if="r._placeholder && currentRole === ROLES.WORKER && r.process === myProcess"
-                @click="openEditor(r)"
-                class="inline-flex items-center gap-1 rounded-md bg-flare-500 px-2 py-1 text-[10px] font-bold text-white hover:bg-flare-600">
-                <Plus class="h-3 w-3" /> 작성
-              </button>
+              <button v-if="!r._placeholder" @click="openViewer(r)" class="rounded-md border border-forena-200 bg-white p-1.5 text-forena-600 hover:bg-forena-50" title="상세 보기"><Eye class="h-3.5 w-3.5" /></button>
+              <button v-if="canEdit(r)" @click="openEditor(r)" class="rounded-md border border-flare-200 bg-flare-50 p-1.5 text-flare-700 hover:bg-flare-100" title="수정"><Pencil class="h-3.5 w-3.5" /></button>
+              <button v-if="r._placeholder && currentRole === ROLES.WORKER && r.process === myProcess" @click="openEditor(r)" class="inline-flex items-center gap-1 rounded-md bg-flare-500 px-2 py-1 text-[10px] font-bold text-white hover:bg-flare-600"><Plus class="h-3 w-3" /> 작성</button>
             </div>
           </div>
-
-          <!-- 카드 본문 -->
+          
           <div v-if="!r._placeholder" class="flex-1 px-4 py-3">
-            <!-- 메트릭 -->
             <div class="grid grid-cols-3 gap-2">
-              <div class="rounded-lg bg-forena-50/40 px-2.5 py-2">
-                <p class="flex items-center gap-1 text-[10px] font-bold text-forena-400">
-                  <Users class="h-3 w-3" /> 인력
+              <div class="rounded-lg bg-forena-50/40 px-2.5 py-2"><p class="flex items-center gap-1 text-[10px] font-bold text-forena-400"><Users class="h-3 w-3" /> 인력</p><p class="mt-0.5 text-base font-bold tabular-nums text-forena-900">{{ r.workers }}<span class="text-[10px] font-normal text-slate-400 ml-0.5">명</span></p></div>
+              <div class="rounded-lg bg-forena-50/40 px-2.5 py-2"><p class="flex items-center gap-1 text-[10px] font-bold text-forena-400"><Wrench class="h-3 w-3" /> 장비</p><p class="mt-0.5 text-base font-bold tabular-nums text-forena-900">{{ r.equipmentCount }}<span class="text-[10px] font-normal text-slate-400 ml-0.5">대</span></p></div>
+              
+              <div class="rounded-lg bg-flare-50/60 px-2.5 py-1.5 flex flex-col justify-center">
+                <p class="flex items-center justify-between text-[10px] font-bold text-flare-600">
+                  전체 진척률
+                  <span class="rounded bg-white px-1 py-0.5 text-[9px] font-bold text-flare-600 shadow-sm border border-flare-100">금일 {{ r.progress }}%</span>
                 </p>
-                <p class="mt-0.5 text-base font-bold tabular-nums text-forena-900">
-                  {{ r.workers }}<span class="text-[10px] font-normal text-slate-400 ml-0.5">명</span>
-                </p>
-              </div>
-              <div class="rounded-lg bg-forena-50/40 px-2.5 py-2">
-                <p class="flex items-center gap-1 text-[10px] font-bold text-forena-400">
-                  <Wrench class="h-3 w-3" /> 장비
-                </p>
-                <p class="mt-0.5 text-base font-bold tabular-nums text-forena-900">
-                  {{ r.equipmentCount }}<span class="text-[10px] font-normal text-slate-400 ml-0.5">대</span>
-                </p>
-              </div>
-              <div class="rounded-lg bg-flare-50/60 px-2.5 py-2">
-                <p class="text-[10px] font-bold text-flare-600">공정 진척률</p>
                 <p class="mt-0.5 text-base font-bold tabular-nums text-flare-700">{{ r.processProgress }}<span class="text-[10px] font-normal ml-0.5">%</span></p>
               </div>
             </div>
-
-            <!-- 진척바 -->
+            
             <div class="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-forena-100">
-              <div class="h-full rounded-full bg-flare-500 transition-all"
-                :style="{ width: r.processProgress + '%' }"></div>
+              <div class="h-full rounded-full bg-flare-500 transition-all" :style="{ width: r.processProgress + '%' }"></div>
             </div>
 
-            <!-- 금일 작업 -->
-            <div class="mt-3">
-              <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">금일 작업 완료</p>
-              <p class="mt-1 text-xs leading-relaxed text-forena-800">{{ r.todayWork || '—' }}</p>
-            </div>
+            <div class="mt-3"><p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">금일 작업 완료</p><p class="mt-1 text-xs leading-relaxed text-forena-800">{{ r.todayWork || '—' }}</p></div>
           </div>
-
-          <!-- placeholder 상태 -->
-          <div v-else class="flex flex-1 flex-col items-center justify-center gap-1.5 px-4 py-8 text-center">
-            <FileText class="h-6 w-6 text-slate-300" />
-            <p class="text-xs text-slate-400">
-              {{ r.process }} 공정 공사일보가 아직 작성되지 않았습니다.
-            </p>
-          </div>
+          <div v-else class="flex flex-1 flex-col items-center justify-center gap-1.5 px-4 py-8 text-center"><FileText class="h-6 w-6 text-slate-300" /><p class="text-xs text-slate-400">{{ r.process }} 공정 공사일보가 아직 작성되지 않았습니다.</p></div>
         </div>
       </div>
-
-      <!-- ============ 명일 작업 예정 ============ -->
-      <div v-else-if="activeTab === 'tomorrow'" class="space-y-3">
-        <p class="text-xs text-forena-500">
-          <span class="font-bold tabular-nums text-forena-700">{{ fmtKor(tomorrowDate) }}</span>
-          기준 공정별 작업 예정 내용입니다.
-        </p>
+      
+      <!-- ============ 명일 작업 예정 탭 영역 ============ -->
+      <div v-else-if="activeTab === 'tomorrow'" class="space-y-3 mt-2">
+        <p class="text-xs text-forena-500"><span class="font-bold tabular-nums text-forena-700">{{ fmtKor(tomorrowDate) }}</span> 기준 공정별 작업 예정 내용입니다.</p>
         <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          <div v-for="r in todayReports" :key="'tomorrow_' + r.id"
-            class="rounded-xl border border-forena-100 bg-white p-4">
-            <div class="flex items-center gap-1.5">
-              <span class="rounded-md bg-forena-50 px-1.5 py-0.5 text-[10px] font-bold text-forena-700">{{ r.process }} 공정</span>
-              <span v-if="r._placeholder" class="rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-bold text-slate-500">계획 미작성</span>
-            </div>
+          <div v-for="r in todayReports" :key="'tomorrow_' + r.id" class="rounded-xl border border-forena-100 bg-white p-4">
+            <div class="flex items-center gap-1.5"><span class="rounded-md bg-forena-50 px-1.5 py-0.5 text-[10px] font-bold text-forena-700">{{ r.process }} 공정</span></div>
             <p class="mt-2 text-[10px] font-bold uppercase tracking-wide text-forena-400">명일 작업 예정</p>
             <p class="mt-1 text-xs leading-relaxed text-forena-800">{{ r.tomorrowPlan || '—' }}</p>
-            <div class="mt-3 flex gap-3 text-[11px] text-forena-500">
-              <span class="inline-flex items-center gap-1"><Users class="h-3 w-3" />예정 인력 {{ r.workers }}명</span>
-              <span class="inline-flex items-center gap-1"><Wrench class="h-3 w-3" />예정 장비 {{ r.equipmentCount }}대</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- ============ 종합 공사일보 (책임자 전용) ============ -->
-      <div v-else-if="activeTab === 'consolidated' && currentRole === ROLES.MANAGER" class="space-y-3">
-        <div class="rounded-xl border border-emerald-200 bg-emerald-50/40 px-4 py-3">
-          <p class="flex items-center gap-1.5 text-xs font-bold text-emerald-800">
-            <FileCheck2 class="h-4 w-4" />
-            {{ fmtKor(selectedDate) }} 종합 공사일보
-          </p>
-          <p class="mt-1 text-[11px] text-emerald-700">
-            전체 {{ stats.total }}개 공정 중 <span class="font-bold">{{ stats.submitted }}건 제출 완료</span>,
-            미제출 {{ stats.pending }}건. 평균 진척률 {{ stats.avgProgress }}%.
-          </p>
-        </div>
-
-        <!-- 공정별 섹션 -->
-        <div v-for="r in todayReports" :key="'consol_' + r.id"
-          class="overflow-hidden rounded-xl border border-forena-100 bg-white">
-          <div class="flex items-center justify-between border-b border-forena-100 bg-forena-50/40 px-4 py-2.5">
-            <div class="flex items-center gap-2">
-              <span class="rounded-md bg-forena-800 px-2 py-0.5 text-[11px] font-bold text-white">{{ r.process }}</span>
-              <span class="text-sm font-bold text-forena-900">{{ r.location || '작업 위치 미입력' }}</span>
-              <span class="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-bold ring-1"
-                :class="statusMeta(r.status).cls">
-                <component :is="statusMeta(r.status).icon" class="h-3 w-3" />{{ r.status }}
-              </span>
-            </div>
-            <span v-if="!r._placeholder" class="rounded-md px-1.5 py-0.5 text-[10px] font-bold ring-1"
-              :class="r.completion === '완료' ? 'bg-emerald-50 text-emerald-700 ring-emerald-200' : 'bg-amber-50 text-amber-700 ring-amber-200'">
-              {{ r.completion }}
-            </span>
-          </div>
-
-          <div v-if="r._placeholder" class="px-4 py-6 text-center text-xs text-slate-400">
-            아직 제출된 공사일보가 없습니다.
-          </div>
-
-          <div v-else class="grid grid-cols-1 gap-x-6 gap-y-3 px-4 py-3 md:grid-cols-2">
-            <div>
-              <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">금일 작업 완료</p>
-              <p class="mt-1 text-xs leading-relaxed text-forena-800">{{ r.todayWork }}</p>
-            </div>
-            <div>
-              <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">명일 작업 예정</p>
-              <p class="mt-1 text-xs leading-relaxed text-forena-800">{{ r.tomorrowPlan }}</p>
-            </div>
-            <div>
-              <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">투입 인력 / 장비</p>
-              <p class="mt-1 text-xs text-forena-800">
-                인력 <span class="font-bold tabular-nums">{{ r.workers }}명</span> ·
-                장비 <span class="font-bold tabular-nums">{{ r.equipmentCount }}대</span>
-                <span v-if="r.equipmentList.length" class="ml-1 text-forena-500">({{ r.equipmentList.join(', ') }})</span>
-              </p>
-            </div>
-            <div>
-              <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">진척률</p>
-              <div class="mt-1.5 flex items-center gap-2">
-                <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-forena-100">
-                  <div class="h-full rounded-full bg-flare-500" :style="{ width: r.processProgress + '%' }"></div>
-                </div>
-                <span class="text-xs font-bold tabular-nums text-flare-700">{{ r.processProgress }}%</span>
-              </div>
-            </div>
-            <div v-if="r.notes" class="md:col-span-2">
-              <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">특이사항</p>
-              <p class="mt-1 text-xs leading-relaxed text-forena-700">{{ r.notes }}</p>
-            </div>
           </div>
         </div>
       </div>
     </div>
 
     <!-- =====================================================
-         작성/수정 모달
+         작성/수정 모달 (에디터 영역)
          ===================================================== -->
     <transition
       enter-active-class="transition duration-150 ease-out"
@@ -732,7 +755,6 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
         class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4"
         @click.self="closeEditor">
         <div class="flex max-h-[92vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl">
-          <!-- 헤더 -->
           <div class="flex shrink-0 items-start justify-between border-b border-forena-100 px-6 py-4">
             <div class="flex items-start gap-3">
               <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-flare-50">
@@ -753,254 +775,153 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
             </button>
           </div>
 
-          <!-- 모달 탭 (금일/명일) -->
           <div class="flex shrink-0 items-center gap-1 border-b border-forena-100 bg-forena-50/30 px-6">
-            <button
-              class="border-b-2 px-3 py-2.5 text-xs font-bold transition"
-              :class="modalTab === 'today' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'"
-              @click="modalTab = 'today'">
-              금일 공사 내용
-            </button>
-            <button
-              class="border-b-2 px-3 py-2.5 text-xs font-bold transition"
-              :class="modalTab === 'tomorrow' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'"
-              @click="modalTab = 'tomorrow'">
-              명일 작업 예정
-            </button>
+            <button class="border-b-2 px-3 py-2.5 text-xs font-bold transition" :class="modalTab === 'today' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'" @click="modalTab = 'today'">금일 공사 내용</button>
+            <button class="border-b-2 px-3 py-2.5 text-xs font-bold transition" :class="modalTab === 'tomorrow' ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'" @click="modalTab = 'tomorrow'">명일 작업 예정</button>
           </div>
 
-          <!-- 본문 (스크롤) -->
           <div class="min-h-0 flex-1 overflow-y-auto px-6 py-4">
-            <!-- 기본 정보 (모든 탭에서 공통) -->
-            <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
-              <div class="sm:col-span-3">
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
-                  <MapPin class="mr-0.5 inline h-3 w-3" />작업 위치 <span class="text-rose-500">*</span>
-                </label>
-                <input v-model="editingReport.location" placeholder="예: 본동 3층 슬라브"
-                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400" />
-              </div>
-              <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
-                  <Users class="mr-0.5 inline h-3 w-3" />작업 인력 수
-                </label>
-                <input type="number" min="0" v-model.number="editingReport.workers"
-                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs tabular-nums outline-none focus:border-flare-400" />
-              </div>
-              <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
-                  <Wrench class="mr-0.5 inline h-3 w-3" />중장비 투입 수
-                </label>
-                <input type="number" min="0" v-model.number="editingReport.equipmentCount"
-                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs tabular-nums outline-none focus:border-flare-400" />
-              </div>
-              <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">완료 / 미완료</label>
-                <select v-model="editingReport.completion"
-                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400">
-                  <option>미완료</option>
-                  <option>완료</option>
-                </select>
-              </div>
-            </div>
-
-            <!-- 장비 목록 -->
-            <div class="mt-4">
-              <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">투입 장비 목록</label>
-              <div class="flex gap-2">
-                <select v-model="editingReport.equipmentInput"
-                  class="flex-1 rounded-lg border border-slate-200 px-3 py-2 text-sm">
-                  <option value="">장비 선택</option>
-                  <optgroup v-for="(items, category) in equipmentList" :key="category" :label="category">
-                    <option v-for="equipment in items" :key="`${category}_${equipment}`" :value="equipment">
-                      {{ equipment }}
-                    </option>
-                  </optgroup>
-                </select>
-                <button @click="addEquipment"
-                  class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-xs font-bold text-flare-700 hover:bg-flare-100">
-                  <Plus class="h-3 w-3" />추가
-                </button>
-              </div>
-              <div v-if="editingReport.equipmentList.length" class="mt-2 flex flex-wrap gap-1.5">
-                <span v-for="(eq, i) in editingReport.equipmentList" :key="i"
-                  class="inline-flex items-center gap-1 rounded-md bg-forena-50 px-2 py-0.5 text-[11px] font-semibold text-forena-700">
-                  {{ eq }}
-                  <button @click="removeEquipment(i)" class="text-slate-400 hover:text-rose-600">
-                    <X class="h-3 w-3" />
-                  </button>
-                </span>
-              </div>
-            </div>
-
-            <!-- ===== 금일 탭 ===== -->
-            <div v-if="modalTab === 'today'" class="mt-6 space-y-4">
-              <!-- 금일 작업 내용 -->
-              <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
-                  금일 작업 완료 내용 <span class="text-rose-500">*</span>
-                </label>
-                <textarea v-model="editingReport.todayWork" rows="4"
-                  placeholder="오늘 완료한 작업 내용을 입력하세요"
-                  class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"></textarea>
+            
+            <div v-if="modalTab === 'today'" class="space-y-4">
+              <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                <div class="sm:col-span-3">
+                  <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"><MapPin class="mr-0.5 inline h-3 w-3" />작업 위치 <span class="text-rose-500">*</span></label>
+                  <input v-model="editingReport.location" class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400" />
+                </div>
+                <div>
+                  <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"><Users class="mr-0.5 inline h-3 w-3" />금일 작업 인력 수</label>
+                  <input type="number" min="0" v-model.number="editingReport.workers" class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs tabular-nums outline-none focus:border-flare-400" />
+                </div>
+                <div class="sm:col-span-2">
+                  <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">완료 / 미완료</label>
+                  <select v-model="editingReport.completion" class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400"><option>미완료</option><option>완료</option></select>
+                </div>
               </div>
 
-              <!-- 금일 진척률 -->
+              <div>
+                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">금일 투입 장비 목록</label>
+                <div class="flex gap-2">
+                  <select v-model="editingReport.equipmentInput.name" class="flex-1 rounded-lg border border-slate-200 px-3 py-2 text-sm"><option value="">장비 선택</option><optgroup v-for="(items, category) in equipmentList" :key="category" :label="category"><option v-for="equipment in items" :key="`${category}_${equipment}`" :value="equipment">{{ equipment }}</option></optgroup></select>
+                  <input type="number" min="1" v-model.number="editingReport.equipmentInput.count" class="w-16 rounded-lg border border-slate-200 px-2 py-2 text-sm text-center tabular-nums" />
+                  <button @click="addEquipment" class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-xs font-bold text-flare-700 hover:bg-flare-100"><Plus class="h-3 w-3" />추가</button>
+                </div>
+                <div v-if="editingReport.equipmentList.length" class="mt-2 flex flex-wrap gap-1.5">
+                  <span v-for="(eq, i) in editingReport.equipmentList" :key="i" class="inline-flex items-center gap-1 rounded-md bg-forena-50 px-2 py-0.5 text-[11px] font-semibold text-forena-700">{{ eq }}<button @click="removeEquipment(i)" class="text-slate-400 hover:text-rose-600"><X class="h-3 w-3" /></button></span>
+                </div>
+              </div>
+
+              <div>
+                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">금일 작업 완료 내용 <span class="text-rose-500">*</span></label>
+                <textarea v-model="editingReport.todayWork" rows="4" class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"></textarea>
+              </div>
+
+              <div>
+                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">공정 기간</label>
+                <div class="grid grid-cols-2 gap-2">
+                  <div>
+                    <label class="mb-0.5 block text-[10px] text-forena-400">시작일</label>
+                    <input type="date" v-model="editingReport.startDate"
+                      class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400" />
+                  </div>
+                  <div>
+                    <label class="mb-0.5 block text-[10px] text-forena-400">종료일</label>
+                    <input type="date" v-model="editingReport.endDate"
+                      class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400" />
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">이전 누적 진척률 (%)</label>
+                <input type="number" min="0" max="100" v-model.number="editingReport.prevProgress" class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs tabular-nums outline-none focus:border-flare-400" />
+              </div>
+
               <div>
                 <div class="mb-1 flex items-center justify-between">
                   <label class="text-[10px] font-bold uppercase tracking-wide text-forena-500">금일 진척률</label>
                   <span class="text-xs font-bold tabular-nums text-flare-700">{{ editingReport.progress }}%</span>
                 </div>
                 <div class="flex items-center gap-3">
-                  <input type="range" min="0" max="100" step="1" v-model.number="editingReport.progress"
-                    class="flex-1 accent-flare-500" />
-                  <input type="number" min="0" max="100" v-model.number="editingReport.progress"
-                    class="w-20 rounded-md border border-forena-200 bg-white px-2 py-1 text-xs tabular-nums outline-none focus:border-flare-400" />
-                </div>
-                <div class="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-forena-100">
-                  <div class="h-full rounded-full bg-flare-500 transition-all" :style="{ width: editingReport.progress + '%' }"></div>
-                </div>
-              </div>
-
-              <!-- 공정 전체 진척률 -->
-              <div>
-                <div class="mb-1 flex items-center justify-between">
-                  <label class="text-[10px] font-bold uppercase tracking-wide text-forena-500">공정 전체 진척률</label>
-                  <span class="text-xs font-bold tabular-nums text-flare-700">{{ editingReport.processProgress }}%</span>
-                </div>
-                <div class="flex items-center gap-3">
-                  <input type="range" min="0" max="100" step="1" v-model.number="editingReport.processProgress"
-                    class="flex-1 accent-flare-500" />
-                  <input type="number" min="0" max="100" v-model.number="editingReport.processProgress"
-                    class="w-20 rounded-md border border-forena-200 bg-white px-2 py-1 text-xs tabular-nums outline-none focus:border-flare-400" />
-                </div>
-                <div class="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-forena-100">
-                  <div class="h-full rounded-full bg-flare-500 transition-all" :style="{ width: editingReport.processProgress + '%' }"></div>
-                </div>
-              </div>
-
-              <!-- 특이사항 -->
-              <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">특이사항</label>
-                <textarea v-model="editingReport.notes" rows="2"
-                  placeholder="안전, 기상, 협의사항 등"
-                  class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"></textarea>
-              </div>
-
-              <!-- ====== 사진 첨부 ====== -->
-              <div class="rounded-xl border border-forena-100 bg-forena-50/30 p-3.5">
-                <div class="mb-2 flex items-center justify-between">
-                  <p class="flex items-center gap-1.5 text-[11px] font-bold text-forena-700">
-                    <ImageIcon class="h-3.5 w-3.5 text-flare-600" />
-                    현장 사진 ({{ editingReport.photos.length }})
-                  </p>
-                  <button @click="pickPhotos"
-                    class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-100">
-                    <Plus class="h-3 w-3" /> 사진 추가
-                  </button>
-                  <input ref="photoInputRef" type="file" class="sr-only"
-                    accept="image/*" multiple @change="onPhotoChange" />
-                </div>
-
-                <!-- 미리보기 그리드 -->
-                <div v-if="editingReport.photos.length"
-                  class="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5">
-                  <div v-for="(photo, i) in editingReport.photos" :key="photo.id"
-                    class="group relative aspect-square overflow-hidden rounded-lg border border-forena-200 bg-white">
-                    <img :src="photo.dataUrl" :alt="photo.name"
-                      class="h-full w-full object-cover" />
-                    <button @click="removePhoto(i)"
-                      class="absolute right-1 top-1 rounded-md bg-slate-900/70 p-1 text-white opacity-0 transition group-hover:opacity-100 hover:bg-rose-600"
-                      title="삭제">
-                      <Trash2 class="h-3 w-3" />
-                    </button>
-                    <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-slate-900/70 to-transparent px-1.5 py-1">
-                      <p class="truncate text-[9px] font-semibold text-white">{{ photo.name }}</p>
-                      <p class="text-[9px] text-white/70">{{ fmtSize(photo.size) }}</p>
+                  <div class="min-w-0 flex-1">
+                    <input type="range" min="0" max="100" step="1" v-model.number="editingReport.progress" class="w-full accent-flare-500" />
+                    <div class="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-forena-100">
+                      <div class="h-full rounded-full bg-flare-500 transition-all" :style="{ width: editingReport.progress + '%' }"></div>
                     </div>
                   </div>
+                  <input type="number" min="0" max="100" v-model.number="editingReport.progress" class="w-20 rounded-md border border-forena-200 bg-white px-2 py-1 text-xs tabular-nums outline-none focus:border-flare-400" />
                 </div>
-                <div v-else
-                  class="flex flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed border-forena-200 bg-white py-6 text-center">
-                  <ImageIcon class="h-5 w-5 text-slate-300" />
-                  <p class="text-[11px] text-slate-400">현장 사진을 업로드하면 여기에 미리보기로 표시됩니다.</p>
-                  <button @click="pickPhotos"
-                    class="mt-1 inline-flex items-center gap-1 rounded-md bg-flare-500 px-2.5 py-1 text-[11px] font-bold text-white hover:bg-flare-600">
-                    <Upload class="h-3 w-3" /> 사진 선택
-                  </button>
-                </div>
+                <p v-if="calcInfo" class="mt-1 text-[10px] text-forena-400">
+                  금일 증가분: <span class="font-semibold text-forena-700">{{ calcInfo.increment }}%</span>
+                  (기간 {{ calcInfo.duration }}일 · 일일 배분율 {{ calcInfo.dailyAllocation }}%)
+                </p>
               </div>
 
-              <!-- ====== 일반 첨부 파일 ====== -->
-              <div class="rounded-xl border border-forena-100 bg-forena-50/30 p-3.5">
+              <div class="rounded-lg border border-flare-100 bg-flare-50/40 p-3">
                 <div class="mb-2 flex items-center justify-between">
-                  <p class="flex items-center gap-1.5 text-[11px] font-bold text-forena-700">
-                    <Paperclip class="h-3.5 w-3.5 text-flare-600" />
-                    첨부 파일 ({{ editingReport.files.length }})
-                    <span class="ml-1 text-[10px] font-normal text-forena-400">PDF · Excel · 이미지</span>
-                  </p>
-                  <button @click="pickFiles"
-                    class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-100">
-                    <Plus class="h-3 w-3" /> 파일 추가
-                  </button>
-                  <input ref="fileInputRef" type="file" class="sr-only"
-                    accept=".pdf,.xls,.xlsx,.csv,image/*" multiple @change="onFileChangeInput" />
+                  <label class="text-[10px] font-bold uppercase tracking-wide text-flare-600">
+                    공정 전체 진척률
+                    <span class="font-normal text-flare-400">(공기 비례 자동 계산)</span>
+                  </label>
+                  <span class="text-sm font-bold tabular-nums text-flare-700">{{ editingReport.processProgress }}%</span>
                 </div>
+                <div class="h-2 w-full overflow-hidden rounded-full bg-flare-100">
+                  <div class="h-full rounded-full bg-flare-500 transition-all" :style="{ width: editingReport.processProgress + '%' }"></div>
+                </div>
+                <p v-if="calcInfo" class="mt-1.5 text-[10px] text-forena-500">
+                  이전 누적 <span class="font-bold text-forena-700">{{ editingReport.prevProgress }}%</span>
+                  + 금일 증가분 <span class="font-bold text-forena-700">{{ calcInfo.increment }}%</span>
+                  = <span class="font-bold text-flare-700">{{ editingReport.processProgress }}%</span>
+                </p>
+                <p v-else class="mt-1.5 text-[10px] text-amber-600">
+                  ⚠ 공정 기간(시작일·종료일)을 입력하면 자동 계산됩니다.
+                </p>
+              </div>
 
-                <ul v-if="editingReport.files.length" class="space-y-1.5">
-                  <li v-for="(f, i) in editingReport.files" :key="f.id"
-                    class="flex items-center gap-2 rounded-lg bg-white px-2.5 py-2 ring-1 ring-forena-100">
-                    <span class="rounded-md bg-flare-50 px-1.5 py-0.5 text-[9px] font-bold text-flare-700">{{ fileBadge(f.type) }}</span>
-                    <span class="flex-1 truncate text-xs text-forena-800">{{ f.name }}</span>
-                    <span class="shrink-0 text-[10px] text-forena-400 tabular-nums">{{ fmtSize(f.size) }}</span>
-                    <button @click="removeFile(i)" class="text-slate-400 hover:text-rose-600">
-                      <Trash2 class="h-3.5 w-3.5" />
-                    </button>
-                  </li>
-                </ul>
-                <p v-else class="text-[11px] text-slate-400">첨부된 파일이 없습니다.</p>
+              <div>
+                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">특이사항</label>
+                <textarea v-model="editingReport.notes" rows="2" class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"></textarea>
               </div>
             </div>
 
-            <!-- ===== 명일 탭 ===== -->
-            <div v-else-if="modalTab === 'tomorrow'" class="mt-6 space-y-4">
-              <!-- 명일 작업 예정 -->
-              <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
-                  명일 작업 예정 내용 <span class="text-rose-500">*</span>
-                </label>
-                <textarea v-model="editingReport.tomorrowPlan" rows="6"
-                  placeholder="내일 진행 예정인 작업 내용을 입력하세요"
-                  class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"></textarea>
+            <div v-else-if="modalTab === 'tomorrow'" class="space-y-4 mt-2">
+              <div class="rounded-lg border border-amber-200 bg-amber-50 p-3 mb-4">
+                <p class="text-xs font-bold text-amber-900">
+                  🔥 아래에 명일 투입 인력과 장비를 설정하시면 내일짜 스케줄(WorkPlan) 원본에 자동으로 업데이트됩니다.
+                </p>
               </div>
 
-              <!-- 안내 텍스트 -->
-              <div class="rounded-lg border border-amber-200 bg-amber-50 p-3">
-                <p class="text-xs text-amber-900">
-                  명일 작업 예정은 금일 공사일보 작성 시 입력됩니다. 내일 진행 예정인 작업 내용을 상세히 작성해주세요.
-                </p>
+              <div class="grid grid-cols-2 gap-3">
+                <div>
+                  <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"><Users class="mr-0.5 inline h-3 w-3" />명일 투입 예정 인력</label>
+                  <input type="number" min="0" v-model.number="editingReport.tomorrowWorkers" class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs tabular-nums outline-none focus:border-flare-400" />
+                </div>
+              </div>
+
+              <div>
+                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">명일 투입 예정 장비</label>
+                <div class="flex gap-2">
+                  <select v-model="editingReport.tomorrowEquipmentInput.name" class="flex-1 rounded-lg border border-slate-200 px-3 py-2 text-sm"><option value="">장비 선택</option><optgroup v-for="(items, category) in equipmentList" :key="category" :label="category"><option v-for="equipment in items" :key="`${category}_${equipment}`" :value="equipment">{{ equipment }}</option></optgroup></select>
+                  <input type="number" min="1" v-model.number="editingReport.tomorrowEquipmentInput.count" class="w-16 rounded-lg border border-slate-200 px-2 py-2 text-sm text-center tabular-nums" />
+                  <button @click="addTomorrowEquipment" class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-xs font-bold text-flare-700 hover:bg-flare-100"><Plus class="h-3 w-3" />추가</button>
+                </div>
+                <div v-if="editingReport.tomorrowEquipmentList.length" class="mt-2 flex flex-wrap gap-1.5">
+                  <span v-for="(eq, i) in editingReport.tomorrowEquipmentList" :key="i" class="inline-flex items-center gap-1 rounded-md bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 ring-1 ring-emerald-200">{{ eq }}<button @click="removeTomorrowEquipment(i)" class="text-slate-400 hover:text-rose-600"><X class="h-3 w-3" /></button></span>
+                </div>
+              </div>
+
+              <div class="mt-4">
+                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">명일 작업 예정 내용 <span class="text-rose-500">*</span></label>
+                <textarea v-model="editingReport.tomorrowPlan" rows="6" class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"></textarea>
               </div>
             </div>
           </div>
 
-          <!-- 푸터 -->
           <div class="flex shrink-0 items-center justify-between gap-2 border-t border-forena-100 bg-forena-50/40 px-6 py-3">
-            <p class="text-[11px] text-forena-500">
-              <span class="text-rose-500">*</span> 표시는 필수 입력 항목입니다.
-            </p>
+            <p class="text-[11px] text-forena-500"><span class="text-rose-500">*</span> 표시는 필수 입력 항목입니다.</p>
             <div class="flex gap-2">
-              <button @click="closeEditor"
-                class="rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-semibold text-forena-700 hover:bg-forena-50">
-                취소
-              </button>
-              <button @click="saveDraft"
-                class="inline-flex items-center gap-1.5 rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-bold text-forena-700 hover:bg-forena-50">
-                <Save class="h-3.5 w-3.5" /> 임시 저장
-              </button>
-              <button @click="submitReport"
-                class="inline-flex items-center gap-1.5 rounded-lg bg-flare-500 px-4 py-2 text-xs font-bold text-white shadow-sm hover:bg-flare-600">
-                <Send class="h-3.5 w-3.5" /> 제출
-              </button>
+              <button @click="closeEditor" class="rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-semibold text-forena-700 hover:bg-forena-50">취소</button>
+              <button @click="saveDraft" class="inline-flex items-center gap-1.5 rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-bold text-forena-700 hover:bg-forena-50"><Save class="h-3.5 w-3.5" /> 임시 저장</button>
+              <button @click="submitReport" class="inline-flex items-center gap-1.5 rounded-lg bg-flare-500 px-4 py-2 text-xs font-bold text-white shadow-sm hover:bg-flare-600"><Send class="h-3.5 w-3.5" /> 제출 (내일 스케줄 업데이트)</button>
             </div>
           </div>
         </div>
@@ -1008,7 +929,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
     </transition>
 
     <!-- =====================================================
-         조회 모달 (책임자가 카드 눈 아이콘 누르면)
+         조회 모달 (상세보기)
          ===================================================== -->
     <transition
       enter-active-class="transition duration-150 ease-out"
@@ -1021,7 +942,6 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
         class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4"
         @click.self="closeViewer">
         <div class="flex max-h-[92vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl">
-          <!-- 헤더 -->
           <div class="flex shrink-0 items-start justify-between border-b border-forena-100 px-6 py-4">
             <div class="flex items-start gap-3">
               <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-forena-50">
@@ -1040,7 +960,6 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
             </button>
           </div>
 
-          <!-- 본문 -->
           <div class="min-h-0 flex-1 overflow-y-auto px-6 py-4">
             <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
               <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
@@ -1064,19 +983,33 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
                 <p class="mt-1 text-2xl font-bold tabular-nums text-forena-900">
                   {{ viewingReport.equipmentCount }}<span class="text-sm font-normal text-slate-400 ml-1">대</span>
                 </p>
-                <p v-if="viewingReport.equipmentList.length" class="mt-1 text-[11px] text-forena-500">
-                  {{ viewingReport.equipmentList.join(', ') }}
-                </p>
+                <div v-if="viewingReport.equipmentList.length" class="mt-1.5 flex flex-wrap gap-1">
+                  <span v-for="(eq, i) in viewingReport.equipmentList" :key="i"
+                    class="inline-flex items-center rounded-md bg-forena-50 px-1.5 py-0.5 text-[10px] font-semibold text-forena-700">
+                    {{ eq }}
+                  </span>
+                </div>
               </div>
             </div>
 
-            <div class="mt-4">
-              <div class="mb-1 flex items-center justify-between">
-                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">공정 진척률</p>
-                <span class="text-xs font-bold tabular-nums text-flare-700">{{ viewingReport.processProgress }}%</span>
+            <div class="mt-4 grid grid-cols-2 gap-3">
+              <div class="rounded-xl border border-forena-100 p-3.5">
+                <div class="mb-1 flex items-center justify-between">
+                  <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">금일 진척률</p>
+                  <span class="text-xs font-bold tabular-nums text-flare-700">{{ viewingReport.progress }}%</span>
+                </div>
+                <div class="h-2 w-full overflow-hidden rounded-full bg-forena-100">
+                  <div class="h-full rounded-full bg-flare-500" :style="{ width: viewingReport.progress + '%' }"></div>
+                </div>
               </div>
-              <div class="h-2 w-full overflow-hidden rounded-full bg-forena-100">
-                <div class="h-full rounded-full bg-flare-500" :style="{ width: viewingReport.processProgress + '%' }"></div>
+              <div class="rounded-xl border border-forena-100 p-3.5">
+                <div class="mb-1 flex items-center justify-between">
+                  <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">공정 전체 진척률</p>
+                  <span class="text-xs font-bold tabular-nums text-flare-700">{{ viewingReport.processProgress }}%</span>
+                </div>
+                <div class="h-2 w-full overflow-hidden rounded-full bg-forena-100">
+                  <div class="h-full rounded-full bg-flare-500" :style="{ width: viewingReport.processProgress + '%' }"></div>
+                </div>
               </div>
             </div>
 
@@ -1095,41 +1028,8 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
               <p class="text-[10px] font-bold uppercase tracking-wide text-amber-700">특이사항</p>
               <p class="mt-1 text-xs leading-relaxed text-amber-900">{{ viewingReport.notes }}</p>
             </div>
-
-            <!-- 사진 -->
-            <div v-if="viewingReport.photos?.length" class="mt-4">
-              <p class="mb-2 flex items-center gap-1.5 text-[11px] font-bold text-forena-700">
-                <ImageIcon class="h-3.5 w-3.5 text-flare-600" />
-                현장 사진 ({{ viewingReport.photos.length }})
-              </p>
-              <div class="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5">
-                <div v-for="photo in viewingReport.photos" :key="photo.id"
-                  class="aspect-square overflow-hidden rounded-lg border border-forena-200 bg-white">
-                  <img :src="photo.dataUrl" :alt="photo.name" class="h-full w-full object-cover" />
-                </div>
-              </div>
-            </div>
-
-            <!-- 첨부 -->
-            <div v-if="viewingReport.files?.length" class="mt-4">
-              <p class="mb-2 flex items-center gap-1.5 text-[11px] font-bold text-forena-700">
-                <Paperclip class="h-3.5 w-3.5 text-flare-600" /> 첨부 파일
-              </p>
-              <ul class="space-y-1.5">
-                <li v-for="f in viewingReport.files" :key="f.id"
-                  class="flex items-center gap-2 rounded-lg bg-white px-2.5 py-2 ring-1 ring-forena-100">
-                  <span class="rounded-md bg-flare-50 px-1.5 py-0.5 text-[9px] font-bold text-flare-700">{{ fileBadge(f.type) }}</span>
-                  <span class="flex-1 truncate text-xs text-forena-800">{{ f.name }}</span>
-                  <span class="shrink-0 text-[10px] text-forena-400 tabular-nums">{{ fmtSize(f.size) }}</span>
-                  <button class="rounded-md p-1 text-forena-400 hover:bg-forena-50 hover:text-forena-700">
-                    <Download class="h-3.5 w-3.5" />
-                  </button>
-                </li>
-              </ul>
-            </div>
           </div>
 
-          <!-- 푸터 (책임자 액션) -->
           <div v-if="currentRole === ROLES.MANAGER"
             class="flex shrink-0 items-center justify-end gap-2 border-t border-forena-100 bg-forena-50/40 px-6 py-3">
             <button @click="rejectReport"
@@ -1139,6 +1039,10 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
             <button @click="approveReport"
               class="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-4 py-2 text-xs font-bold text-white shadow-sm hover:bg-emerald-600">
               <CheckCircle2 class="h-3.5 w-3.5" /> 승인
+            </button>
+            <button @click="closeViewer"
+              class="rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-semibold text-forena-700 hover:bg-forena-50">
+              닫기
             </button>
           </div>
         </div>

--- a/src/views/schedule/WorkInstructionView.vue
+++ b/src/views/schedule/WorkInstructionView.vue
@@ -1,225 +1,204 @@
 <script setup>
+// feat : Vue Composition API 및 아이콘, API 모듈 임포트
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import api from '@/api/index'
 import {
-  CalendarDays, ChevronLeft, ChevronRight, FileText, Plus, Save, Send, Eye,
-  Pencil, Users, Wrench, MapPin, ClipboardList, CheckCircle2, AlertTriangle,
-  Clock, ShieldCheck, UserCog, Trash2, X, Layers, Sparkles, RefreshCw,
-  Truck, DoorOpen, Image as ImageIcon, Paperclip, Search, Filter,
-  ArrowRightLeft, Download
+  CalendarDays,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  Plus,
+  Save,
+  Send,
+  Eye,
+  Pencil,
+  Users,
+  Wrench,
+  MapPin,
+  ClipboardList,
+  CheckCircle2,
+  AlertTriangle,
+  Clock,
+  ShieldCheck,
+  UserCog,
+  Trash2,
+  X,
+  Layers,
+  Sparkles,
+  RefreshCw,
+  Truck,
+  DoorOpen,
+  Image as ImageIcon,
+  Paperclip,
+  Search,
+  Filter,
+  ArrowRightLeft,
+  Download,
 } from 'lucide-vue-next'
 
-// =========================================================
-// 권한 / 사용자 (데모용 토글)
-// =========================================================
+import {
+  createWorkOrder,
+  getWorkOrderList,
+  updateWorkOrder,
+  approveWorkOrder,
+} from '@/api/workOrder'
+
+// feat : 한글 장비명과 영문 Enum 간의 매핑 상수
+const EQUIPMENT_ENUM_MAP = {
+  굴삭기: 'EXCAVATOR',
+  미니굴삭기: 'MINI_EXCAVATOR',
+  백호: 'BACKHOE_LOADER',
+  드래그라인: 'DRAGLINE_EXCAVATOR',
+  덤프트럭: 'DUMP_TRUCK',
+  '트럭 믹서': 'CONCRETE_MIXER_TRUCK',
+  트랙터: 'TRACTOR',
+  트레일러: 'TRAILER',
+  스크레이퍼: 'SCRAPER',
+  타워크레인: 'TOWER_CRANE',
+  '모바일 크레인': 'MOBILE_CRANE',
+  '크롤러 크레인': 'CRAWLER_CRANE',
+  지게차: 'FORKLIFT',
+  리프트: 'CONSTRUCTION_HOIST',
+  불도저: 'BULLDOZER',
+  '모터 그레이더': 'MOTOR_GRADER',
+  롤러: 'ROAD_ROLLER',
+  콤팩터: 'PLATE_COMPACTOR',
+  '아스팔트 피니셔': 'ASPHALT_PAVER',
+  '밀링 머신': 'MILLING_MACHINE',
+  살수차: 'WATER_TRUCK',
+  '노면 절단기': 'CONCRETE_CUTTER',
+  '파일 드라이버': 'PILE_DRIVER',
+  보링머신: 'BORING_MACHINE',
+  어스오거: 'EARTH_AUGER',
+  RCD: 'REVERSE_CIRCULATION_DRILL',
+  '콘크리트 펌프카': 'CONCRETE_PUMP_TRUCK',
+  '배치 플랜트': 'BATCHING_PLANT',
+  바이브레이터: 'CONCRETE_VIBRATOR',
+  브레이커: 'HYDRAULIC_BREAKER',
+  니블러: 'NIBBLER',
+  크러셔: 'CRUSHER',
+  고소작업차: 'AERIAL_WORK_PLATFORM',
+  TBM: 'TUNNEL_BORING_MACHINE',
+}
+
+// feat : 영문 Enum을 한글 장비명으로 역매핑
+const ENUM_TO_KOR_MAP = Object.fromEntries(
+  Object.entries(EQUIPMENT_ENUM_MAP).map(([k, v]) => [v, k]),
+)
+
+// feat : 사용자 권한 및 공정 기본 설정
 const ROLES = {
   MANAGER: 'site_manager',
-  WORKER:  'process_owner',
+  WORKER: 'process_owner',
 }
 const currentRole = ref(ROLES.WORKER)
 const ALL_PROCESSES = ['토공', '골조', '철근', '전기', '설비', '마감']
 const myProcess = ref('철근')
 
+// feat : 장비 선택 옵션
 const equipmentList = {
   '굴착·토공': ['굴삭기', '미니굴삭기', '백호', '드래그라인'],
-  '운반': ['덤프트럭', '트럭 믹서', '트랙터', '트레일러', '스크레이퍼'],
+  운반: ['덤프트럭', '트럭 믹서', '트랙터', '트레일러', '스크레이퍼'],
   '하역·양중': ['타워크레인', '모바일 크레인', '크롤러 크레인', '지게차', '리프트'],
   '정지·다짐': ['불도저', '모터 그레이더', '롤러', '콤팩터'],
   '도로·포장': ['아스팔트 피니셔', '밀링 머신', '살수차', '노면 절단기'],
   '기초·파일': ['파일 드라이버', '보링머신', '어스오거', 'RCD'],
-  '콘크리트': ['콘크리트 펌프카', '배치 플랜트', '바이브레이터'],
+  콘크리트: ['콘크리트 펌프카', '배치 플랜트', '바이브레이터'],
   '철거·특수': ['브레이커', '니블러', '크러셔', '고소작업차', 'TBM'],
 }
 
-// =========================================================
-// 게이트 (현장 등록 게이트)
-// =========================================================
-const GATES = [
-  { id: 'G1', name: '1번 게이트', desc: '북측 정문' },
-  { id: 'G2', name: '2번 게이트', desc: '동측 자재 게이트' },
-  { id: 'G3', name: '3번 게이트', desc: '남측 토사 반출' },
-  { id: 'G4', name: '4번 게이트', desc: '서측 비상' },
-]
-const GATE_CAPACITY = 6 // 게이트 당 동시 수용 가능 장비 수 (혼잡도 기준)
+// feat : 게이트 목록 및 상태 정보를 담을 반응형 변수
+const GATES = ref([])
+const GATE_CAPACITY = 6 // 혼잡도를 판별할 기준 대수
 
-// =========================================================
-// 날짜
-// =========================================================
-function todayStr() { return new Date().toISOString().slice(0, 10) }
-function addDays(dateStr, n) {
-  const d = new Date(dateStr); d.setDate(d.getDate() + n)
-  return d.toISOString().slice(0, 10)
+// feat : DB에서 게이트 목록과 실시간 장비 점유 상태를 함께 조회
+async function fetchGates() {
+  try {
+    // 나중에 팀원이 만든 API 엔드포인트에 맞춰 수정.
+    // 현재는 게이트 정보와 해당 게이트의 '현재 대기 대수'를 같이 준다고 가정.
+    const response = await api.get('/gates/status', { params: { siteIdx: 1 } })
+    const data = response.data?.data || response.data || []
+
+    // feat : 받아온 데이터를 화면에서 쓰기 좋게 매핑
+    GATES.value = data.map((g) => ({
+      gateIdx: g.gateIdx, // DB PK (팀원과 맞출 컬럼)
+      gateName: g.gateName, // 화면 표시용 이름
+      currentCount: g.currentCount || 0, // 현재 해당 게이트 점유 대수
+      // feat : 대기 대수에 따른 상태값 계산
+      status: (g.currentCount || 0) >= GATE_CAPACITY ? '혼잡' : '원활',
+    }))
+  } catch (error) {
+    console.error('게이트 상태 정보 조회 실패:', error)
+    // API 에러 시 기본값 세팅 (테스트용)
+    GATES.value = [
+      { gateIdx: 1, gateName: '1번 게이트', currentCount: 0, status: '원활' },
+      { gateIdx: 2, gateName: '2번 게이트', currentCount: 0, status: '원활' },
+    ]
+  }
+}
+
+// feat : 게이트 이름과 상태를 같이 보여주는 포맷터
+function getGateLabel(g) {
+  return `${g.gateName} (${g.status})`
+}
+
+// feat : 컴포넌트 마운트 시 호출
+onMounted(() => {
+  fetchGates() // 게이트 정보 먼저 로드
+  fetchWorkOrders()
+})
+
+function todayStr() {
+  return new Date().toISOString().slice(0, 10)
 }
 function fmtKor(dateStr) {
   if (!dateStr) return ''
   const d = new Date(dateStr)
-  const dow = ['일','월','화','수','목','금','토'][d.getDay()]
-  return `${d.getMonth()+1}월 ${d.getDate()}일 (${dow})`
+  const dow = ['일', '월', '화', '수', '목', '금', '토'][d.getDay()]
+  return `${d.getMonth() + 1}월 ${d.getDate()}일 (${dow})`
 }
 
 const filterDate = ref(todayStr())
-const filterProcess = ref('all') // 활성 탭
+const filterProcess = ref('all')
 const filterPartner = ref('')
 const filterStatus = ref('')
 const searchKeyword = ref('')
 
-// =========================================================
-// 작업 지시서 상태
-// =========================================================
-const STATUS_LIST = ['작성 전','초안 생성','임시 저장','승인 대기','검토 중','승인 완료','반려','작업 완료']
+const STATUS_LIST = [
+  '작성 전',
+  '초안 생성',
+  '임시 저장',
+  '승인 대기',
+  '검토 중',
+  '승인 완료',
+  '반려',
+  '작업 완료',
+]
 const STATUS_META = {
-  '작성 전':   { cls: 'bg-slate-100 text-slate-500 ring-slate-200',         icon: Clock },
-  '초안 생성': { cls: 'bg-flare-50 text-flare-700 ring-flare-200',          icon: Sparkles },
-  '임시 저장': { cls: 'bg-amber-50 text-amber-700 ring-amber-200',          icon: Pencil },
-  '승인 대기': { cls: 'bg-sky-50 text-sky-700 ring-sky-200',                icon: Send },
-  '검토 중':   { cls: 'bg-violet-50 text-violet-700 ring-violet-200',       icon: Eye },
-  '승인 완료': { cls: 'bg-emerald-50 text-emerald-700 ring-emerald-200',    icon: CheckCircle2 },
-  '반려':      { cls: 'bg-rose-50 text-rose-700 ring-rose-200',             icon: AlertTriangle },
-  '작업 완료': { cls: 'bg-emerald-100 text-emerald-800 ring-emerald-300',   icon: CheckCircle2 },
+  '작성 전': { cls: 'bg-slate-100 text-slate-500 ring-slate-200', icon: Clock },
+  '초안 생성': { cls: 'bg-flare-50 text-flare-700 ring-flare-200', icon: Sparkles },
+  '임시 저장': { cls: 'bg-amber-50 text-amber-700 ring-amber-200', icon: Pencil },
+  '승인 대기': { cls: 'bg-sky-50 text-sky-700 ring-sky-200', icon: Send },
+  '검토 중': { cls: 'bg-violet-50 text-violet-700 ring-violet-200', icon: Eye },
+  '승인 완료': { cls: 'bg-emerald-50 text-emerald-700 ring-emerald-200', icon: CheckCircle2 },
+  반려: { cls: 'bg-rose-50 text-rose-700 ring-rose-200', icon: AlertTriangle },
+  '작업 완료': { cls: 'bg-emerald-100 text-emerald-800 ring-emerald-300', icon: CheckCircle2 },
 }
-function statusMeta(s) { return STATUS_META[s] || STATUS_META['작성 전'] }
-
-// =========================================================
-// 데모 데이터: 공사일보의 명일 작업 예정 (초안 생성 소스)
-// =========================================================
-// (전일 작성된 공사일보의 tomorrowPlan을 시뮬레이션)
-const tomorrowPlanSource = ref([
-  {
-    process: '토공', date: todayStr(),
-    location: 'B3층 동측 굴착 구역',
-    plan: '잔여 토사 반출 마무리, 굴착 바닥 정리. 흙막이 변위 추가 점검.',
-    expectedWorkers: 14,
-    expectedEquipment: [
-      { name: '굴삭기', count: 1 },
-      { name: '덤프트럭', count: 3 },
-    ],
-    workTime: '07:00 ~ 17:00',
-  },
-  {
-    process: '골조', date: todayStr(),
-    location: '지상 5층 동·서측',
-    plan: '4층 양생 관리 병행, 5층 거푸집 설치 시작.',
-    expectedWorkers: 22,
-    expectedEquipment: [
-      { name: '타워크레인', count: 1 },
-      { name: '콘크리트 펌프카', count: 1 },
-    ],
-    workTime: '07:00 ~ 18:00',
-  },
-  {
-    process: '철근', date: todayStr(),
-    location: '본동 3층 슬라브',
-    plan: '3층 슬라브 상부 철근 배근 마무리, 검측 요청.',
-    expectedWorkers: 12,
-    expectedEquipment: [
-      { name: '철근 절곡기', count: 1 },
-    ],
-    workTime: '07:00 ~ 17:00',
-  },
-  {
-    process: '전기', date: todayStr(),
-    location: 'B2층 전기실',
-    plan: 'B2층 잔여 배관 설치, 배관 청소 및 검측.',
-    expectedWorkers: 6,
-    expectedEquipment: [
-      { name: '고소작업대', count: 1 },
-    ],
-    workTime: '08:00 ~ 17:00',
-  },
-])
-
-function planFor(process, date) {
-  return tomorrowPlanSource.value.find(p => p.process === process && p.date === date) || null
+function statusMeta(s) {
+  return STATUS_META[s] || STATUS_META['작성 전']
 }
 
-// =========================================================
-// 작업 지시서 (데모)
-// =========================================================
-function makeId() { return `WO-${Math.random().toString(36).slice(2, 7).toUpperCase()}` }
+function makeId() {
+  return `WO-${Math.random().toString(36).slice(2, 7).toUpperCase()}`
+}
+const workOrders = ref([])
 
-const workOrders = ref([
-  {
-    id: 'WO-A1B2C', date: todayStr(),
-    process: '토공', partner: '한울중기',
-    location: 'B3층 동측 굴착 구역',
-    workTime: '07:00 ~ 17:00',
-    workers: 14,
-    equipment: [
-      { id: 'eq1', name: '굴삭기', count: 1, gateIn: 'G3', gateOut: 'G3' },
-      { id: 'eq2', name: '덤프트럭', count: 3, gateIn: 'G3', gateOut: 'G3' },
-    ],
-    workDetail: '잔여 토사 반출 마무리, 굴착 바닥 정리, 흙막이 변위 추가 점검.',
-    safety: '굴착부 추락 방지 안전난간 확인. 덤프트럭 후진 시 신호수 배치.',
-    notes: '오후 강우 예보, 우천 시 작업 중지 검토.',
-    files: [
-      { id: 'f1', name: '토공_4월29일_작업계획서.pdf', size: 482000, type: 'application/pdf' },
-    ],
-    photos: [],
-    author: '김토공', createdAt: '2026-04-28 18:10',
-    status: '승인 대기',
-    history: [
-      { at: '2026-04-28 17:30', who: '김토공', what: '초안 생성' },
-      { at: '2026-04-28 18:10', who: '김토공', what: '승인 대기' },
-    ],
-  },
-  {
-    id: 'WO-D3E4F', date: todayStr(),
-    process: '골조', partner: '대한건설',
-    location: '지상 5층 동·서측',
-    workTime: '07:00 ~ 18:00',
-    workers: 22,
-    equipment: [
-      { id: 'eq3', name: '타워크레인', count: 1, gateIn: 'G2', gateOut: 'G2' },
-      { id: 'eq4', name: '콘크리트 펌프카', count: 1, gateIn: 'G2', gateOut: 'G2' },
-    ],
-    workDetail: '4층 양생 관리, 5층 거푸집 설치 시작 (동측 → 서측 순).',
-    safety: '거푸집 인양 작업 반경 통제. 신호수 1명 상시 배치.',
-    notes: '',
-    files: [],
-    photos: [],
-    author: '박골조', createdAt: '2026-04-28 17:50',
-    status: '승인 완료',
-    history: [
-      { at: '2026-04-28 17:50', who: '박골조', what: '승인 대기' },
-      { at: '2026-04-28 19:20', who: '현장소장', what: '승인 완료' },
-    ],
-  },
-  {
-    id: 'WO-G5H6I', date: todayStr(),
-    process: '전기', partner: '대우전기',
-    location: 'B2층 전기실',
-    workTime: '08:00 ~ 17:00',
-    workers: 6,
-    equipment: [
-      { id: 'eq5', name: '고소작업대', count: 1, gateIn: 'G2', gateOut: 'G2' },
-    ],
-    workDetail: 'B2층 잔여 배관 설치 및 배관 청소.',
-    safety: '고소작업대 안전벨트 착용 필수. 정전 작업 절차 준수.',
-    notes: '천장 간섭 구간 1개소 협의 후 진행.',
-    files: [],
-    photos: [],
-    author: '최전기', createdAt: '2026-04-28 18:30',
-    status: '승인 완료',
-    history: [
-      { at: '2026-04-28 18:30', who: '최전기', what: '승인 대기' },
-      { at: '2026-04-28 20:00', who: '현장소장', what: '승인 완료' },
-    ],
-  },
-])
-
-// =========================================================
-// 권한별 보이는 탭
-// =========================================================
 const visibleTabs = computed(() => {
-  if (currentRole.value === ROLES.WORKER) {
+  if (currentRole.value === ROLES.WORKER)
     return [{ key: myProcess.value, label: `${myProcess.value} 공정` }]
-  }
-  return [
-    { key: 'all', label: '전체' },
-    ...ALL_PROCESSES.map(p => ({ key: p, label: p })),
-  ]
+  return [{ key: 'all', label: '전체' }, ...ALL_PROCESSES.map((p) => ({ key: p, label: p }))]
 })
 
-// 담당자라면 탭을 myProcess로 자동 고정
 function onRoleChange(role) {
   currentRole.value = role
   if (role === ROLES.WORKER) filterProcess.value = myProcess.value
@@ -229,97 +208,88 @@ function onMyProcessChange() {
   if (currentRole.value === ROLES.WORKER) filterProcess.value = myProcess.value
 }
 
-// =========================================================
-// 필터링
-// =========================================================
 const filteredOrders = computed(() => {
   let r = workOrders.value
-  // 권한 필터: 담당자는 본인 공정만
-  if (currentRole.value === ROLES.WORKER) {
-    r = r.filter(o => o.process === myProcess.value)
-  } else if (filterProcess.value !== 'all') {
-    r = r.filter(o => o.process === filterProcess.value)
-  }
-  if (filterDate.value) r = r.filter(o => o.date === filterDate.value)
-  if (filterPartner.value) r = r.filter(o => o.partner.includes(filterPartner.value))
-  if (filterStatus.value) r = r.filter(o => o.status === filterStatus.value)
+  if (currentRole.value === ROLES.WORKER) r = r.filter((o) => o.process === myProcess.value)
+  else if (filterProcess.value !== 'all') r = r.filter((o) => o.process === filterProcess.value)
+  if (filterDate.value) r = r.filter((o) => o.date === filterDate.value)
+  if (filterPartner.value) r = r.filter((o) => o.partner.includes(filterPartner.value))
+  if (filterStatus.value) r = r.filter((o) => o.status === filterStatus.value)
   if (searchKeyword.value.trim()) {
     const k = searchKeyword.value.trim().toLowerCase()
-    r = r.filter(o =>
-      o.location.toLowerCase().includes(k) ||
-      o.workDetail.toLowerCase().includes(k) ||
-      o.id.toLowerCase().includes(k)
+    r = r.filter(
+      (o) =>
+        o.location.toLowerCase().includes(k) ||
+        o.workDetail.toLowerCase().includes(k) ||
+        o.id.toLowerCase().includes(k),
     )
   }
   return r
 })
 
-const partners = computed(() => {
-  const set = new Set(workOrders.value.map(o => o.partner))
-  return Array.from(set)
-})
-
-// 책임자: 오늘자 미작성 공정 알림
+const partners = computed(() => Array.from(new Set(workOrders.value.map((o) => o.partner))))
 const missingProcesses = computed(() => {
   if (currentRole.value !== ROLES.MANAGER) return []
   const existing = new Set(
-    workOrders.value.filter(o => o.date === filterDate.value).map(o => o.process)
+    workOrders.value.filter((o) => o.date === filterDate.value).map((o) => o.process),
   )
-  return ALL_PROCESSES.filter(p => !existing.has(p))
+  return ALL_PROCESSES.filter((p) => !existing.has(p))
 })
 
-// =========================================================
-// 게이트 배정 현황 (선택된 날짜 기준)
-// =========================================================
+// feat : 게이트 혼잡도 계산 로직 (에러 픽스: GATES.value 사용 및 gateIdx 매핑)
 const gateAssignment = computed(() => {
   const map = {}
-  GATES.forEach(g => map[g.id] = { in: 0, out: 0 })
+  GATES.value.forEach((g) => (map[g.gateIdx] = { in: 0, out: 0 }))
   workOrders.value
-    .filter(o => o.date === filterDate.value)
-    .forEach(o => {
-      o.equipment.forEach(eq => {
-        if (eq.gateIn && map[eq.gateIn])  map[eq.gateIn].in  += eq.count || 0
+    .filter((o) => o.date === filterDate.value)
+    .forEach((o) => {
+      o.equipment.forEach((eq) => {
+        if (eq.gateIn && map[eq.gateIn]) map[eq.gateIn].in += eq.count || 0
         if (eq.gateOut && map[eq.gateOut]) map[eq.gateOut].out += eq.count || 0
       })
     })
-  return GATES.map(g => {
-    const a = map[g.id]
+  return GATES.value.map((g) => {
+    const a = map[g.gateIdx] || { in: 0, out: 0 }
     const total = a.in + a.out
     const ratio = total / GATE_CAPACITY
     let level = 'low'
     if (ratio >= 1) level = 'high'
     else if (ratio >= 0.66) level = 'mid'
-    return { ...g, in: a.in, out: a.out, total, ratio: Math.min(ratio, 1.5), level }
+    return {
+      ...g,
+      in: a.in,
+      out: a.out,
+      total,
+      ratio: Math.min(ratio, 1.5),
+      level,
+      name: g.gateName,
+      desc: '',
+    }
   })
 })
 
-// 편집 중 보고서의 임시 게이트 점유까지 합산하려면 별도 계산도 가능 — 여기선 단순화
-
-// =========================================================
-// 작성/수정 모달
-// =========================================================
 const showEditor = ref(false)
 const editing = ref(null)
 const isNew = ref(false)
-// 편집 중 자동 초안 영역
-const draftSourcePlan = ref(null)   // 명일 작업 원문
-const draftAutoFilled = ref({})     // 어떤 필드가 자동 입력됐는지 표시
+const draftSourcePlan = ref(null)
+const draftAutoFilled = ref({})
 
 function canEdit(order) {
   if (currentRole.value === ROLES.MANAGER) return false
   if (order.process !== myProcess.value) return false
-  if (['승인 완료','작업 완료'].includes(order.status)) return false
+  if (['승인 완료', '작업 완료'].includes(order.status)) return false
   return true
 }
 
-function openCreate() {
+async function openCreate() {
   isNew.value = true
   editing.value = blankOrder()
-  // 작성 시작 시 자동 초안을 띄울지 여부는 사용자가 버튼으로 선택
   draftSourcePlan.value = null
   draftAutoFilled.value = {}
   showEditor.value = true
+  await generateDraft(true)
 }
+
 function openEdit(order) {
   isNew.value = false
   editing.value = cloneOrder(order)
@@ -327,6 +297,7 @@ function openEdit(order) {
   draftAutoFilled.value = {}
   showEditor.value = true
 }
+
 function closeEditor() {
   showEditor.value = false
   editing.value = null
@@ -338,13 +309,17 @@ function blankOrder() {
   return {
     id: makeId(),
     date: filterDate.value,
-    process: currentRole.value === ROLES.WORKER ? myProcess.value : (filterProcess.value !== 'all' ? filterProcess.value : ALL_PROCESSES[0]),
+    process:
+      currentRole.value === ROLES.WORKER
+        ? myProcess.value
+        : filterProcess.value !== 'all'
+          ? filterProcess.value
+          : ALL_PROCESSES[0],
     partner: '',
     location: '',
     workTime: '',
     workers: 0,
-    equipment: [],
-    equipmentInput: { name: '', count: 1, gateIn: 'G1', gateOut: 'G1' },
+    equipmentInput: { name: '', count: 1, gateIn: 1, gateOut: 1 },
     workDetail: '',
     safety: '',
     notes: '',
@@ -356,56 +331,132 @@ function blankOrder() {
     history: [],
   }
 }
+
 function cloneOrder(o) {
   return {
     ...o,
-    equipment: o.equipment.map(e => ({ ...e })),
-    equipmentInput: { name: '', count: 1, gateIn: 'G1', gateOut: 'G1' },
-    files: o.files.map(f => ({ ...f })),
-    photos: (o.photos || []).map(p => ({ ...p })),
+    equipment: o.equipment.map((e) => ({ ...e })),
+    equipmentInput: { name: '', count: 1, gateIn: 1, gateOut: 1 },
+    files: o.files.map((f) => ({ ...f })),
+    photos: (o.photos || []).map((p) => ({ ...p })),
     history: [...(o.history || [])],
   }
 }
 
-// 명일 작업 예정 → 초안 자동 생성
-function generateDraft() {
+// feat : 워크오더 API 조회 + 실패 시 대비한 무적의 3중 Fallback 안전모드 장착
+async function generateDraft(isAutoMode = false) {
   if (!editing.value) return
-  const plan = planFor(editing.value.process, addDays(editing.value.date, -1))
-              || planFor(editing.value.process, editing.value.date)
-  if (!plan) {
-    alert(`${editing.value.process} 공정의 명일 작업 예정 내용을 찾지 못했습니다.\n공사일보가 먼저 작성되어 있어야 합니다.`)
-    return
+  try {
+    const response = await api.get('/work-plan', { params: { planType: '주간' } })
+    const plans = Array.isArray(response) ? response : response?.data?.data || response?.data || []
+
+    const targetDate = editing.value.date
+    const targetProcess = editing.value.process
+
+    const toDateString = (dateVal) => {
+      if (Array.isArray(dateVal))
+        return `${dateVal[0]}-${String(dateVal[1]).padStart(2, '0')}-${String(dateVal[2]).padStart(2, '0')}`
+      return dateVal
+    }
+
+    let targetPlan = plans.find(
+      (p) =>
+        (p.trade === targetProcess || p.tradeType === targetProcess) &&
+        p.name &&
+        p.name.includes('(명일 예정)') &&
+        toDateString(p.startDate) === targetDate,
+    )
+    if (!targetPlan)
+      targetPlan = plans.find(
+        (p) =>
+          (p.trade === targetProcess || p.tradeType === targetProcess) &&
+          toDateString(p.startDate) === targetDate,
+      )
+    if (!targetPlan)
+      targetPlan = plans.find(
+        (p) =>
+          (p.trade === targetProcess || p.tradeType === targetProcess) &&
+          targetDate >= toDateString(p.startDate) &&
+          targetDate <= toDateString(p.endDate),
+      )
+
+    if (!targetPlan) {
+      if (!isAutoMode)
+        alert(`DB에서 ${targetDate} 일자의 [${targetProcess}] 계획을 찾지 못했습니다.`)
+      return
+    }
+
+    draftSourcePlan.value = { plan: targetPlan.name }
+    editing.value.workPlanId = targetPlan.idx
+    editing.value.location = targetPlan.location
+    editing.value.partner = targetPlan.partner || ''
+    editing.value.workTime = '07:00 ~ 17:00'
+    editing.value.workers = targetPlan.requiredCount || 0
+    editing.value.workDetail = targetPlan.name + (targetPlan.note ? '\n' + targetPlan.note : '')
+
+    const eqList = []
+
+    try {
+      // 1순위: 깔끔하게 백엔드 DB에서 직접 조회 시도
+      const eqRes = await api.get(`/work-order/draft-equipments/${targetPlan.idx}`)
+      const equipments = eqRes.data?.data || eqRes.data || []
+
+      if (equipments.length > 0) {
+        equipments.forEach((eq, i) => {
+          const korName = ENUM_TO_KOR_MAP[eq.equipmentName] || eq.equipmentName
+          eqList.push({
+            id: `eq_${Date.now()}_${i}`,
+            name: korName,
+            count: eq.equipmentCount || 1,
+            gateIn: 1,
+            gateOut: 1,
+          })
+        })
+      } else {
+        throw new Error('API 응답이 비어있음')
+      }
+    } catch (apiError) {
+      console.warn('API 직접 조회 실패, 안전 모드로 자체 복구 시도:', apiError)
+      // 2순위: 혹시 백엔드가 터졌으면 프론트가 문자열을 쪼개서라도 무조건 렌더링함!
+      if (targetPlan.equipmentDisplay) {
+        const items = targetPlan.equipmentDisplay.split(',')
+        items.forEach((item, i) => {
+          const match = item.trim().match(/(.+)\s+(\d+)대/)
+          if (match)
+            eqList.push({
+              id: `eq_fb_${Date.now()}_${i}`,
+              name: match[1].trim(),
+              count: parseInt(match[2], 10),
+              gateIn: 1,
+              gateOut: 1,
+            })
+        })
+      }
+    }
+
+    editing.value.equipment = eqList
+    draftAutoFilled.value = {
+      location: true,
+      workTime: true,
+      workers: true,
+      workDetail: true,
+      equipment: true,
+    }
+    if (editing.value.status === '작성 전') editing.value.status = '초안 생성'
+  } catch (error) {
+    console.error('계획 데이터 자동 연동 실패:', error)
   }
-  draftSourcePlan.value = plan
-  // 자동 입력
-  editing.value.location   = plan.location
-  editing.value.workTime   = plan.workTime
-  editing.value.workers    = plan.expectedWorkers
-  editing.value.workDetail = plan.plan
-  // 장비도 자동으로 채워넣되, 게이트는 기본값(G1)
-  editing.value.equipment = plan.expectedEquipment.map((eq, i) => ({
-    id: `eq_${Date.now()}_${i}`,
-    name: eq.name,
-    count: eq.count,
-    gateIn: 'G1',
-    gateOut: 'G1',
-  }))
-  draftAutoFilled.value = {
-    location: true, workTime: true, workers: true,
-    workDetail: true, equipment: true,
-  }
-  if (editing.value.status === '작성 전') editing.value.status = '초안 생성'
 }
-function regenerateDraft() {
+
+async function regenerateDraft() {
   if (!confirm('현재 입력 내용이 초안으로 다시 덮어쓰여집니다. 계속할까요?')) return
-  generateDraft()
+  await generateDraft()
 }
+
 function clearDraftHighlight(field) {
-  // 사용자가 수정한 필드는 자동입력 표시 해제
   if (draftAutoFilled.value[field]) draftAutoFilled.value[field] = false
 }
 
-// 장비 추가/삭제
 function addEquipment() {
   const inp = editing.value.equipmentInput
   if (!inp.name.trim() || inp.count < 1) return
@@ -422,43 +473,55 @@ function removeEquipment(idx) {
   editing.value.equipment.splice(idx, 1)
 }
 
-// 첨부 (사진 + 파일) — 디자인 일관성 위해 동일 패턴
 const photoInputRef = ref(null)
 const fileInputRef = ref(null)
-function pickPhotos() { photoInputRef.value?.click() }
-function pickFiles()  { fileInputRef.value?.click() }
+function pickPhotos() {
+  photoInputRef.value?.click()
+}
+function pickFiles() {
+  fileInputRef.value?.click()
+}
+
 function onPhotoChange(e) {
-  const list = Array.from(e.target.files || [])
-  list.forEach(f => {
+  Array.from(e.target.files || []).forEach((f) => {
     if (!f.type.startsWith('image/')) return
     const reader = new FileReader()
-    reader.onload = (ev) => {
+    reader.onload = (ev) =>
       editing.value.photos.push({
-        id: `p_${Date.now()}_${Math.random().toString(36).slice(2,6)}`,
-        name: f.name, size: f.size, dataUrl: ev.target.result,
+        id: `p_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        name: f.name,
+        size: f.size,
+        dataUrl: ev.target.result,
       })
-    }
     reader.readAsDataURL(f)
   })
   e.target.value = ''
 }
+
 function onFileChangeInput(e) {
-  const list = Array.from(e.target.files || [])
-  list.forEach(f => {
+  Array.from(e.target.files || []).forEach((f) =>
     editing.value.files.push({
-      id: `f_${Date.now()}_${Math.random().toString(36).slice(2,6)}`,
-      name: f.name, size: f.size, type: f.type,
-    })
-  })
+      id: `f_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+      name: f.name,
+      size: f.size,
+      type: f.type,
+    }),
+  )
   e.target.value = ''
 }
-function removePhoto(idx) { editing.value.photos.splice(idx, 1) }
-function removeFile(idx)  { editing.value.files.splice(idx, 1) }
+
+function removePhoto(idx) {
+  editing.value.photos.splice(idx, 1)
+}
+function removeFile(idx) {
+  editing.value.files.splice(idx, 1)
+}
+
 function fmtSize(bytes) {
   if (!bytes && bytes !== 0) return ''
   if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes/1024).toFixed(1)} KB`
-  return `${(bytes/1024/1024).toFixed(1)} MB`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 function fileBadge(type) {
   if (!type) return '파일'
@@ -468,21 +531,57 @@ function fileBadge(type) {
   return '파일'
 }
 
-// 임시저장 / 제출
 function saveDraft() {
   persist('임시 저장', '임시 저장')
 }
-function submitOrder() {
+
+// feat : 작업 지시서 제출 (숫자 타입인 gateIdx를 그대로 사용하도록 수정)
+async function submitOrder() {
   const r = editing.value
   if (!r.partner.trim() || !r.location.trim() || !r.workTime.trim() || !r.workDetail.trim()) {
-    alert('협력사 / 작업 위치 / 작업 시간 / 작업 상세 내역은 필수입니다.')
+    alert('필수 항목을 입력해주세요.')
     return
   }
-  if (r.equipment.length === 0) {
-    if (!confirm('투입 장비가 없습니다. 그대로 제출하시겠습니까?')) return
+
+  // feat : 장비 리스트 매핑 (replace 제거 및 숫자 데이터 직접 전송)
+  const equipmentList = r.equipment.map((eq) => ({
+    // eq.gateIn이 이제 숫자(1, 2...)이므로 바로 할당합니다.
+    gateIdx: eq.gateIn,
+    equipmentName: EQUIPMENT_ENUM_MAP[eq.name] || 'EXCAVATOR',
+    equipmentCount: eq.count,
+  }))
+
+  const requestPayload = {
+    siteIdx: 1,
+    partnerCompanyIdx: 1,
+    workPlanId: r.workPlanId,
+    tradeType: r.process,
+    title: `[${r.process}] ${r.location} 작업지시서`,
+    instructionContent: `${r.workDetail}\n\n[작업시간] ${r.workTime}\n[안전사항] ${r.safety}`,
+    dueDate: r.date,
+    workerCount: r.workers,
+    equipments: equipmentList,
   }
-  persist('승인 대기', '승인 대기')
+
+  try {
+    if (isNew.value) {
+      requestPayload.statusCode = 'OPEN'
+      await createWorkOrder(requestPayload)
+      alert('작업 지시서가 성공적으로 전송되었습니다!')
+    } else {
+      const rawId = r.id.replace('WO-', '')
+      requestPayload.statusCode = 'OPEN'
+      await updateWorkOrder(rawId, requestPayload)
+      alert('작업 지시서가 성공적으로 수정되었습니다!')
+    }
+    closeEditor()
+    await fetchWorkOrders()
+  } catch (error) {
+    console.error('API 에러:', error)
+    alert('저장 실패: 서버 오류가 발생했습니다.')
+  }
 }
+
 function persist(newStatus, historyLabel) {
   const r = editing.value
   delete r.equipmentInput
@@ -492,152 +591,288 @@ function persist(newStatus, historyLabel) {
     who: r.author,
     what: historyLabel,
   })
-  const idx = workOrders.value.findIndex(x => x.id === r.id)
+  const idx = workOrders.value.findIndex((x) => x.id === r.id)
   if (idx >= 0) workOrders.value.splice(idx, 1, { ...r })
   else workOrders.value.push({ ...r })
   closeEditor()
 }
 
-// =========================================================
-// 상세 보기 (책임자/조회 공통)
-// =========================================================
 const viewing = ref(null)
-function openViewer(o) { viewing.value = o }
-function closeViewer() { viewing.value = null }
-
-function approve() {
-  const idx = workOrders.value.findIndex(o => o.id === viewing.value.id)
-  if (idx < 0) return
-  workOrders.value[idx].status = '승인 완료'
-  workOrders.value[idx].history.push({
-    at: new Date().toISOString().slice(0, 16).replace('T', ' '),
-    who: '현장소장', what: '승인 완료',
-  })
-  viewing.value = workOrders.value[idx]
+function openViewer(o) {
+  viewing.value = o
 }
-function reject() {
-  const idx = workOrders.value.findIndex(o => o.id === viewing.value.id)
-  if (idx < 0) return
-  workOrders.value[idx].status = '반려'
-  workOrders.value[idx].history.push({
-    at: new Date().toISOString().slice(0, 16).replace('T', ' '),
-    who: '현장소장', what: '반려',
-  })
-  viewing.value = workOrders.value[idx]
+function closeViewer() {
+  viewing.value = null
+}
+function editViewing() {
+  if (!viewing.value) return
+  const order = viewing.value
+  closeViewer()
+  openEdit(order)
+}
+async function approve() {
+  if (!confirm('이 작업 지시서를 승인하시겠습니까?')) return
+  await updateOrderStatus('승인 완료', 'APPROVED')
+}
+async function reject() {
+  if (!confirm('이 작업 지시서를 반려하시겠습니까?')) return
+  await updateOrderStatus('반려', 'REJECTED')
 }
 
-// 게이트 이름 헬퍼
-function gateName(id) { return GATES.find(g => g.id === id)?.name || id }
+// feat : 작업 지시서 상태 업데이트 (승인은 전용 엔드포인트 사용)
+async function updateOrderStatus(newStatus, statusCodeStr) {
+  const order = viewing.value
+  if (!order) return
 
-// ESC 닫기
+  const rawId = order.id.replace('WO-', '')
+
+  try {
+    if (statusCodeStr === 'APPROVED') {
+      // ★ 승인: 전용 엔드포인트 호출 → 백엔드가 WorkPlan까지 동기화
+      await approveWorkOrder(rawId)
+    } else {
+      // 반려/기타: 기존 방식 유지 (페이로드 구성)
+      const requestPayload = {
+        siteIdx: 1,
+        partnerCompanyIdx: 1,
+        tradeType: order.process,
+        title: `[${order.process}] ${order.location} 작업지시서`,
+        instructionContent: `${order.workDetail}\n\n[작업시간] ${order.workTime}\n[안전사항] ${order.safety}`,
+        dueDate: order.date,
+        workerCount: order.workers || 0,
+        statusCode: statusCodeStr,
+        equipments: order.equipment.map((eq) => {
+          const safeGateIdx =
+            typeof eq.gateIn === 'string' ? parseInt(eq.gateIn.replace(/\D/g, ''), 10) : eq.gateIn
+          return {
+            gateIdx: safeGateIdx || 1,
+            equipmentName: EQUIPMENT_ENUM_MAP[eq.name] || 'EXCAVATOR',
+            equipmentCount: eq.count || 1,
+          }
+        }),
+      }
+      await updateWorkOrder(rawId, requestPayload)
+    }
+
+    // 로컬 상태 업데이트
+    const idx = workOrders.value.findIndex((o) => o.id === order.id)
+    if (idx >= 0) {
+      workOrders.value[idx].status = newStatus
+      workOrders.value[idx].history.push({
+        at: new Date().toISOString().slice(0, 16).replace('T', ' '),
+        who: '현장소장',
+        what: newStatus,
+      })
+    }
+    alert(`성공적으로 ${newStatus} 처리되었습니다!`)
+    closeViewer()
+  } catch (e) {
+    console.error('상태 업데이트 API 오류:', e)
+    alert('상태 변경에 실패했습니다. 서버 오류를 확인해주세요.')
+  }
+}
+
+// feat : 게이트 고유 번호로 이름을 찾는 유틸 함수 수정
+function gateName(id) {
+  return GATES.value.find((g) => g.gateIdx === id)?.gateName || id
+}
 function onKeydown(e) {
   if (e.key !== 'Escape') return
   if (showEditor.value) closeEditor()
   else if (viewing.value) closeViewer()
 }
-onMounted(() => document.addEventListener('keydown', onKeydown))
+
+async function fetchWorkOrders() {
+  try {
+    const response = await getWorkOrderList()
+    let serverData = Array.isArray(response)
+      ? response
+      : response?.data?.data || response?.data || []
+    if (!Array.isArray(serverData)) return
+
+    workOrders.value = serverData.map((dto) => {
+      let locationStr = dto.title
+        ? dto.title.replace(`[${dto.tradeType}] `, '').replace(' 작업지시서', '')
+        : ''
+      let detail = dto.instructionContent || ''
+      let time = ''
+      let safetyText = ''
+      if (detail.includes('[작업시간]')) {
+        const parts = detail.split('[작업시간]')
+        detail = parts[0].trim()
+        const subParts = parts[1].split('[안전사항]')
+        time = subParts[0] ? subParts[0].trim() : ''
+        if (subParts.length > 1) safetyText = subParts[1].trim()
+      }
+      return {
+        id: `WO-${dto.idx}`,
+        date: dto.dueDate,
+        process: dto.tradeType,
+        partner: '한울중기',
+        location: locationStr,
+        workTime: time,
+        workers: dto.workerCount || 0,
+        workDetail: detail,
+        safety: safetyText,
+        notes: '',
+        status:
+          dto.statusCode === 'APPROVED'
+            ? '승인 완료'
+            : dto.statusCode === 'REJECTED'
+              ? '반려'
+              : dto.statusCode === 'OPEN'
+                ? '승인 대기'
+                : '작성 전',
+        author: '작성자',
+        createdAt: '-',
+        files: [],
+        photos: [],
+        history: [],
+        equipment: (dto.equipments || []).map((eq) => ({
+          id: `eq_${eq.idx}`,
+          name: ENUM_TO_KOR_MAP[eq.equipmentName] || eq.equipmentName,
+          count: eq.equipmentCount,
+          gateIn: `G${eq.gateIdx}`,
+          gateOut: `G${eq.gateIdx}`,
+        })),
+      }
+    })
+  } catch (e) {
+    console.error('데이터 불러오기 실패:', e)
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', onKeydown)
+  fetchWorkOrders()
+})
 onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
 </script>
 
 <template>
   <div class="flex h-full min-h-0 flex-col gap-4 pb-6">
-
-    <!-- ========== 헤더 ========== -->
     <div class="flex shrink-0 flex-wrap items-center justify-between gap-3">
       <div>
         <p class="text-[11px] font-bold uppercase tracking-widest text-flare-600">현장 운영</p>
         <h1 class="text-xl font-bold text-forena-900">작업 지시서</h1>
       </div>
       <div class="flex flex-wrap items-center gap-2">
-        <!-- 권한 토글 -->
         <div class="flex overflow-hidden rounded-lg border border-forena-200 bg-white">
           <button
             class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold transition"
-            :class="currentRole === ROLES.WORKER ? 'bg-forena-800 text-white' : 'text-forena-600 hover:bg-forena-50'"
-            @click="onRoleChange(ROLES.WORKER)">
+            :class="
+              currentRole === ROLES.WORKER
+                ? 'bg-forena-800 text-white'
+                : 'text-forena-600 hover:bg-forena-50'
+            "
+            @click="onRoleChange(ROLES.WORKER)"
+          >
             <UserCog class="h-3.5 w-3.5" /> 공정 담당자
           </button>
           <button
             class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-bold transition"
-            :class="currentRole === ROLES.MANAGER ? 'bg-forena-800 text-white' : 'text-forena-600 hover:bg-forena-50'"
-            @click="onRoleChange(ROLES.MANAGER)">
+            :class="
+              currentRole === ROLES.MANAGER
+                ? 'bg-forena-800 text-white'
+                : 'text-forena-600 hover:bg-forena-50'
+            "
+            @click="onRoleChange(ROLES.MANAGER)"
+          >
             <ShieldCheck class="h-3.5 w-3.5" /> 현장 총 관리자
           </button>
         </div>
-        <select v-if="currentRole === ROLES.WORKER" v-model="myProcess" @change="onMyProcessChange"
-          class="rounded-lg border border-forena-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-forena-700 outline-none focus:border-flare-400">
+        <select
+          v-if="currentRole === ROLES.WORKER"
+          v-model="myProcess"
+          @change="onMyProcessChange"
+          class="rounded-lg border border-forena-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-forena-700 outline-none focus:border-flare-400"
+        >
           <option v-for="p in ALL_PROCESSES" :key="p" :value="p">{{ p }} 공정</option>
         </select>
 
-        <button @click="openCreate"
-          class="inline-flex items-center gap-1.5 rounded-lg bg-flare-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm hover:bg-flare-600">
+        <button
+          @click="openCreate"
+          class="inline-flex items-center gap-1.5 rounded-lg bg-flare-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm hover:bg-flare-600"
+        >
           <Plus class="h-3.5 w-3.5" /> 작업 지시서 작성
         </button>
       </div>
     </div>
 
-    <!-- ========== 권한 안내 ========== -->
-    <div v-if="currentRole === ROLES.WORKER"
-      class="flex shrink-0 items-start gap-2.5 rounded-xl border border-flare-200 bg-flare-50/60 px-4 py-3">
+    <div
+      v-if="currentRole === ROLES.WORKER"
+      class="flex shrink-0 items-start gap-2.5 rounded-xl border border-flare-200 bg-flare-50/60 px-4 py-3"
+    >
       <UserCog class="mt-0.5 h-4 w-4 shrink-0 text-flare-600" />
       <p class="text-xs text-forena-800">
         현재 계정은 <span class="font-bold text-flare-700">{{ myProcess }} 공정 담당자</span>입니다.
         {{ myProcess }} 공정 작업 지시서만 조회 · 작성 · 수정할 수 있습니다.
       </p>
     </div>
-    <div v-else
-      class="flex shrink-0 items-start gap-2.5 rounded-xl border border-emerald-200 bg-emerald-50/60 px-4 py-3">
+    <div
+      v-else
+      class="flex shrink-0 items-start gap-2.5 rounded-xl border border-emerald-200 bg-emerald-50/60 px-4 py-3"
+    >
       <ShieldCheck class="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
       <p class="text-xs text-forena-800">
-        현재 계정은 <span class="font-bold text-emerald-700">현장 총 관리자</span>입니다.
-        전체 공정 작업 지시서를 조회하고 승인/반려할 수 있습니다.
+        현재 계정은 <span class="font-bold text-emerald-700">현장 총 관리자</span>입니다. 전체 공정
+        작업 지시서를 조회하고 승인/반려할 수 있습니다.
         <span v-if="missingProcesses.length" class="ml-1 font-bold text-rose-600">
           · 미작성 공정: {{ missingProcesses.join(', ') }}
         </span>
       </p>
     </div>
 
-    <!-- ========== 필터 바 ========== -->
-    <div class="flex shrink-0 flex-wrap items-center gap-3 rounded-xl border border-forena-100 bg-white px-4 py-3">
-      <!-- 날짜 -->
+    <div
+      class="flex shrink-0 flex-wrap items-center gap-3 rounded-xl border border-forena-100 bg-white px-4 py-3"
+    >
       <div class="flex items-center gap-1">
         <CalendarDays class="h-4 w-4 text-flare-600" />
-        <input type="date" v-model="filterDate"
-          class="rounded-md border border-forena-200 bg-white px-2 py-1 text-xs font-semibold tabular-nums text-forena-800 outline-none focus:border-flare-400" />
+        <input
+          type="date"
+          v-model="filterDate"
+          class="rounded-md border border-forena-200 bg-white px-2 py-1 text-xs font-semibold tabular-nums text-forena-800 outline-none focus:border-flare-400"
+        />
       </div>
-      <!-- 협력사 -->
       <div class="flex items-center gap-1.5">
         <span class="text-[11px] font-bold text-forena-400">협력사</span>
-        <select v-model="filterPartner"
-          class="rounded-md border border-forena-200 bg-white px-2 py-1 text-xs text-forena-800 outline-none focus:border-flare-400">
+        <select
+          v-model="filterPartner"
+          class="rounded-md border border-forena-200 bg-white px-2 py-1 text-xs text-forena-800 outline-none focus:border-flare-400"
+        >
           <option value="">전체</option>
           <option v-for="p in partners" :key="p">{{ p }}</option>
         </select>
       </div>
-      <!-- 상태 -->
       <div class="flex items-center gap-1.5">
         <span class="text-[11px] font-bold text-forena-400">상태</span>
-        <select v-model="filterStatus"
-          class="rounded-md border border-forena-200 bg-white px-2 py-1 text-xs text-forena-800 outline-none focus:border-flare-400">
+        <select
+          v-model="filterStatus"
+          class="rounded-md border border-forena-200 bg-white px-2 py-1 text-xs text-forena-800 outline-none focus:border-flare-400"
+        >
           <option value="">전체</option>
           <option v-for="s in STATUS_LIST" :key="s">{{ s }}</option>
         </select>
       </div>
-      <!-- 검색 -->
       <div class="flex items-center gap-1 rounded-md border border-forena-200 bg-white px-2">
         <Search class="h-3.5 w-3.5 text-forena-400" />
-        <input v-model="searchKeyword" placeholder="위치/지시서 번호/내용"
-          class="w-44 bg-transparent py-1 text-xs text-forena-800 outline-none placeholder:text-forena-300" />
+        <input
+          v-model="searchKeyword"
+          placeholder="위치/지시서 번호/내용"
+          class="w-44 bg-transparent py-1 text-xs text-forena-800 outline-none placeholder:text-forena-300"
+        />
       </div>
-
       <span class="ml-auto text-[11px] text-forena-500">
-        조회 결과 <span class="font-bold text-forena-800 tabular-nums">{{ filteredOrders.length }}</span>건
+        조회 결과
+        <span class="font-bold text-forena-800 tabular-nums">{{ filteredOrders.length }}</span
+        >건
       </span>
     </div>
 
-    <!-- ========== 게이트 배정 현황 (책임자 전용) ========== -->
-    <div v-if="currentRole === ROLES.MANAGER"
-      class="shrink-0 rounded-xl border border-forena-100 bg-white p-4">
+    <div
+      v-if="currentRole === ROLES.MANAGER"
+      class="shrink-0 rounded-xl border border-forena-100 bg-white p-4"
+    >
       <div class="mb-3 flex items-center justify-between">
         <div class="flex items-center gap-2">
           <DoorOpen class="h-4 w-4 text-flare-600" />
@@ -647,59 +882,97 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
         <span class="text-[10px] text-forena-400">게이트 수용 기준 {{ GATE_CAPACITY }}대</span>
       </div>
       <div class="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
-        <div v-for="g in gateAssignment" :key="g.id"
+        <div
+          v-for="g in gateAssignment"
+          :key="g.id"
           class="rounded-xl border p-3"
-          :class="g.level === 'high' ? 'border-rose-200 bg-rose-50/40'
-                  : g.level === 'mid' ? 'border-amber-200 bg-amber-50/40'
-                  : 'border-forena-100 bg-forena-50/30'">
+          :class="
+            g.level === 'high'
+              ? 'border-rose-200 bg-rose-50/40'
+              : g.level === 'mid'
+                ? 'border-amber-200 bg-amber-50/40'
+                : 'border-forena-100 bg-forena-50/30'
+          "
+        >
           <div class="flex items-start justify-between">
             <div>
               <p class="text-xs font-bold text-forena-900">{{ g.name }}</p>
               <p class="text-[10px] text-forena-500">{{ g.desc }}</p>
             </div>
-            <span v-if="g.level === 'high'"
-              class="inline-flex items-center gap-1 rounded-md bg-rose-100 px-1.5 py-0.5 text-[10px] font-bold text-rose-700">
+            <span
+              v-if="g.level === 'high'"
+              class="inline-flex items-center gap-1 rounded-md bg-rose-100 px-1.5 py-0.5 text-[10px] font-bold text-rose-700"
+            >
               <AlertTriangle class="h-3 w-3" /> 과밀
             </span>
-            <span v-else-if="g.level === 'mid'"
-              class="rounded-md bg-amber-100 px-1.5 py-0.5 text-[10px] font-bold text-amber-700">혼잡</span>
-            <span v-else class="rounded-md bg-emerald-100 px-1.5 py-0.5 text-[10px] font-bold text-emerald-700">원활</span>
+            <span
+              v-else-if="g.level === 'mid'"
+              class="rounded-md bg-amber-100 px-1.5 py-0.5 text-[10px] font-bold text-amber-700"
+              >혼잡</span
+            >
+            <span
+              v-else
+              class="rounded-md bg-emerald-100 px-1.5 py-0.5 text-[10px] font-bold text-emerald-700"
+              >원활</span
+            >
           </div>
           <div class="mt-2 flex items-center gap-3 text-[11px] text-forena-700">
             <span class="inline-flex items-center gap-1">
-              <ChevronRight class="h-3 w-3 text-emerald-500" />입차 <b class="tabular-nums">{{ g.in }}</b>대
+              <ChevronRight class="h-3 w-3 text-emerald-500" />입차
+              <b class="tabular-nums">{{ g.in }}</b
+              >대
             </span>
             <span class="inline-flex items-center gap-1">
-              <ChevronLeft class="h-3 w-3 text-rose-500" />출차 <b class="tabular-nums">{{ g.out }}</b>대
+              <ChevronLeft class="h-3 w-3 text-rose-500" />출차
+              <b class="tabular-nums">{{ g.out }}</b
+              >대
             </span>
           </div>
           <div class="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-forena-100">
-            <div class="h-full rounded-full transition-all"
-              :class="g.level === 'high' ? 'bg-rose-500' : g.level === 'mid' ? 'bg-amber-500' : 'bg-emerald-500'"
-              :style="{ width: Math.min(g.ratio * 100, 100) + '%' }"></div>
+            <div
+              class="h-full rounded-full transition-all"
+              :class="
+                g.level === 'high'
+                  ? 'bg-rose-500'
+                  : g.level === 'mid'
+                    ? 'bg-amber-500'
+                    : 'bg-emerald-500'
+              "
+              :style="{ width: Math.min(g.ratio * 100, 100) + '%' }"
+            ></div>
           </div>
         </div>
       </div>
     </div>
 
-    <!-- ========== 공정 탭 ========== -->
     <div class="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-forena-100">
-      <button v-for="t in visibleTabs" :key="t.key"
+      <button
+        v-for="t in visibleTabs"
+        :key="t.key"
         @click="filterProcess = t.key"
         class="shrink-0 border-b-2 px-4 py-2 text-xs font-bold transition"
-        :class="filterProcess === t.key ? 'border-flare-500 text-flare-700' : 'border-transparent text-forena-500 hover:text-forena-700'">
+        :class="
+          filterProcess === t.key
+            ? 'border-flare-500 text-flare-700'
+            : 'border-transparent text-forena-500 hover:text-forena-700'
+        "
+      >
         {{ t.label }}
       </button>
     </div>
 
-    <!-- ========== 작업 지시서 목록 ========== -->
     <div class="min-h-0 flex-1 overflow-y-auto">
-      <div v-if="!filteredOrders.length"
-        class="flex flex-col items-center justify-center gap-2 py-16 text-center">
+      <div
+        v-if="!filteredOrders.length"
+        class="flex flex-col items-center justify-center gap-2 py-16 text-center"
+      >
         <FileText class="h-8 w-8 text-slate-300" />
         <p class="text-sm text-slate-400">조회된 작업 지시서가 없습니다.</p>
-        <button v-if="currentRole === ROLES.WORKER" @click="openCreate"
-          class="mt-1 inline-flex items-center gap-1 rounded-md bg-flare-500 px-3 py-1.5 text-xs font-bold text-white hover:bg-flare-600">
+        <button
+          v-if="currentRole === ROLES.WORKER"
+          @click="openCreate"
+          class="mt-1 inline-flex items-center gap-1 rounded-md bg-flare-500 px-3 py-1.5 text-xs font-bold text-white hover:bg-flare-600"
+        >
           <Plus class="h-3 w-3" /> 새 작업 지시서 작성
         </button>
       </div>
@@ -720,12 +993,17 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
             </tr>
           </thead>
           <tbody class="divide-y divide-forena-100">
-            <tr v-for="o in filteredOrders" :key="o.id"
+            <tr
+              v-for="o in filteredOrders"
+              :key="o.id"
               class="cursor-pointer hover:bg-forena-50/40"
-              @click="openViewer(o)">
+              @click="openViewer(o)"
+            >
               <td class="px-3 py-3">
-                <span class="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-bold ring-1"
-                  :class="statusMeta(o.status).cls">
+                <span
+                  class="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-bold ring-1"
+                  :class="statusMeta(o.status).cls"
+                >
                   <component :is="statusMeta(o.status).icon" class="h-3 w-3" />
                   {{ o.status }}
                 </span>
@@ -741,7 +1019,9 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
                 </p>
               </td>
               <td class="px-3 py-3 tabular-nums text-forena-700">{{ o.workTime }}</td>
-              <td class="px-3 py-3 text-center font-bold tabular-nums text-forena-900">{{ o.workers }}</td>
+              <td class="px-3 py-3 text-center font-bold tabular-nums text-forena-900">
+                {{ o.workers }}
+              </td>
               <td class="px-3 py-3">
                 <div v-if="o.equipment.length" class="space-y-0.5">
                   <p v-for="eq in o.equipment" :key="eq.id" class="text-[11px] text-forena-700">
@@ -755,12 +1035,19 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
               </td>
               <td class="px-3 py-3 text-forena-700">{{ o.author }}</td>
               <td class="px-3 py-3 text-right" @click.stop>
-                <button @click="openViewer(o)"
-                  class="rounded-md border border-forena-200 bg-white p-1.5 text-forena-600 hover:bg-forena-50" title="상세 보기">
+                <button
+                  @click="openViewer(o)"
+                  class="rounded-md border border-forena-200 bg-white p-1.5 text-forena-600 hover:bg-forena-50"
+                  title="상세 보기"
+                >
                   <Eye class="h-3.5 w-3.5" />
                 </button>
-                <button v-if="canEdit(o)" @click="openEdit(o)"
-                  class="ml-1 rounded-md border border-flare-200 bg-flare-50 p-1.5 text-flare-700 hover:bg-flare-100" title="수정">
+                <button
+                  v-if="canEdit(o)"
+                  @click="openEdit(o)"
+                  class="ml-1 rounded-md border border-flare-200 bg-flare-50 p-1.5 text-flare-700 hover:bg-flare-100"
+                  title="수정"
+                >
                   <Pencil class="h-3.5 w-3.5" />
                 </button>
               </td>
@@ -770,24 +1057,29 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
       </div>
     </div>
 
-    <!-- =====================================================
-         작성/수정 모달
-         ===================================================== -->
     <transition
       enter-active-class="transition duration-150 ease-out"
       enter-from-class="opacity-0"
       enter-to-class="opacity-100"
       leave-active-class="transition duration-100 ease-in"
       leave-from-class="opacity-100"
-      leave-to-class="opacity-0">
-      <div v-if="showEditor && editing"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="showEditor && editing"
         class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4"
-        @click.self="closeEditor">
-        <div class="flex max-h-[94vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl">
-          <!-- 헤더 -->
-          <div class="flex shrink-0 items-start justify-between border-b border-forena-100 px-6 py-4">
+        @click.self="closeEditor"
+      >
+        <div
+          class="flex max-h-[94vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl"
+        >
+          <div
+            class="flex shrink-0 items-start justify-between border-b border-forena-100 px-6 py-4"
+          >
             <div class="flex items-start gap-3">
-              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-flare-50">
+              <div
+                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-flare-50"
+              >
                 <ClipboardList class="h-5 w-5 text-flare-600" />
               </div>
               <div>
@@ -806,112 +1098,182 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
             </button>
           </div>
 
-          <!-- 본문 (스크롤) -->
           <div class="min-h-0 flex-1 overflow-y-auto px-6 py-4">
-
-            <!-- ===== 자동 초안 생성 섹션 ===== -->
             <div class="rounded-xl border border-flare-200 bg-flare-50/40 p-4">
               <div class="flex items-start justify-between gap-3">
                 <div class="flex items-start gap-2.5">
                   <Sparkles class="mt-0.5 h-4 w-4 shrink-0 text-flare-600" />
                   <div>
-                    <p class="text-xs font-bold text-forena-900">명일 작업 예정으로 초안 자동 생성</p>
+                    <p class="text-xs font-bold text-forena-900">
+                      명일 작업 예정으로 초안 자동 생성
+                    </p>
                     <p class="mt-0.5 text-[11px] text-forena-600">
-                      전일 공사일보의 명일 작업 예정 내용을 불러와
-                      작업 위치 · 시간 · 인원 · 장비 · 상세를 자동 입력합니다. 게이트는 직접 지정하세요.
+                      전일 공사일보의 명일 작업 예정 내용을 불러와 작업 위치 · 시간 · 인원 · 장비 ·
+                      상세를 자동 입력합니다. 게이트는 직접 지정하세요.
                     </p>
                   </div>
                 </div>
                 <div class="flex shrink-0 gap-1.5">
-                  <button v-if="!draftSourcePlan" @click="generateDraft"
-                    class="inline-flex items-center gap-1 rounded-md bg-flare-500 px-2.5 py-1 text-[11px] font-bold text-white hover:bg-flare-600">
+                  <button
+                    v-if="!draftSourcePlan"
+                    @click="generateDraft"
+                    class="inline-flex items-center gap-1 rounded-md bg-flare-500 px-2.5 py-1 text-[11px] font-bold text-white hover:bg-flare-600"
+                  >
                     <Sparkles class="h-3 w-3" /> 초안 생성
                   </button>
-                  <button v-else @click="regenerateDraft"
-                    class="inline-flex items-center gap-1 rounded-md border border-flare-300 bg-white px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-50">
+                  <button
+                    v-else
+                    @click="regenerateDraft"
+                    class="inline-flex items-center gap-1 rounded-md border border-flare-300 bg-white px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-50"
+                  >
                     <RefreshCw class="h-3 w-3" /> 다시 생성
                   </button>
                 </div>
               </div>
 
-              <!-- 원문 미리보기 -->
-              <div v-if="draftSourcePlan" class="mt-3 rounded-lg bg-white p-3 ring-1 ring-flare-100">
-                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">원문 (전일 공사일보 명일 작업)</p>
-                <p class="mt-1 text-[11px] leading-relaxed text-forena-700">{{ draftSourcePlan.plan }}</p>
+              <div
+                v-if="draftSourcePlan"
+                class="mt-3 rounded-lg bg-white p-3 ring-1 ring-flare-100"
+              >
+                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">
+                  원문 (전일 공사일보 명일 작업)
+                </p>
+                <p class="mt-1 text-[11px] leading-relaxed text-forena-700">
+                  {{ draftSourcePlan.plan }}
+                </p>
               </div>
             </div>
 
-            <!-- ===== 기본 정보 ===== -->
             <div class="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-3">
               <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">작업 일 <span class="text-rose-500">*</span></label>
-                <input type="date" v-model="editing.date"
-                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400" />
+                <label
+                  class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
+                  >작업 일 <span class="text-rose-500">*</span></label
+                >
+                <input
+                  type="date"
+                  v-model="editing.date"
+                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400"
+                />
               </div>
               <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
+                <label
+                  class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
+                >
                   작업 시간 <span class="text-rose-500">*</span>
-                  <span v-if="draftAutoFilled.workTime" class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700">자동</span>
+                  <span
+                    v-if="draftAutoFilled.workTime"
+                    class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700"
+                    >자동</span
+                  >
                 </label>
-                <input v-model="editing.workTime" placeholder="예: 07:00 ~ 17:00"
+                <input
+                  v-model="editing.workTime"
+                  placeholder="예: 07:00 ~ 17:00"
                   @input="clearDraftHighlight('workTime')"
                   class="w-full rounded-md border bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400"
-                  :class="draftAutoFilled.workTime ? 'border-flare-300' : 'border-forena-200'" />
+                  :class="draftAutoFilled.workTime ? 'border-flare-300' : 'border-forena-200'"
+                />
               </div>
               <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">공정 명</label>
-                <select v-model="editing.process"
+                <label
+                  class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
+                  >공정 명</label
+                >
+                <select
+                  v-model="editing.process"
                   :disabled="currentRole === ROLES.WORKER"
-                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400 disabled:bg-forena-50/40">
+                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400 disabled:bg-forena-50/40"
+                >
                   <option v-for="p in ALL_PROCESSES" :key="p">{{ p }}</option>
                 </select>
               </div>
               <div class="sm:col-span-2">
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">협력사 명 <span class="text-rose-500">*</span></label>
-                <input v-model="editing.partner" placeholder="예: 한울중기"
-                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400" />
+                <label
+                  class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
+                  >협력사 명 <span class="text-rose-500">*</span></label
+                >
+                <input
+                  v-model="editing.partner"
+                  placeholder="예: 한울중기"
+                  class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400"
+                />
               </div>
               <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
+                <label
+                  class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
+                >
                   필요 인원
-                  <span v-if="draftAutoFilled.workers" class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700">자동</span>
+                  <span
+                    v-if="draftAutoFilled.workers"
+                    class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700"
+                    >자동</span
+                  >
                 </label>
-                <input type="number" min="0" v-model.number="editing.workers"
+                <input
+                  type="number"
+                  min="0"
+                  v-model.number="editing.workers"
                   @input="clearDraftHighlight('workers')"
                   class="w-full rounded-md border bg-white px-2.5 py-1.5 text-xs tabular-nums outline-none focus:border-flare-400"
-                  :class="draftAutoFilled.workers ? 'border-flare-300' : 'border-forena-200'" />
+                  :class="draftAutoFilled.workers ? 'border-flare-300' : 'border-forena-200'"
+                />
               </div>
               <div class="sm:col-span-3">
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
-                  <MapPin class="mr-0.5 inline h-3 w-3" />작업 위치 <span class="text-rose-500">*</span>
-                  <span v-if="draftAutoFilled.location" class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700">자동</span>
+                <label
+                  class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
+                >
+                  <MapPin class="mr-0.5 inline h-3 w-3" />작업 위치
+                  <span class="text-rose-500">*</span>
+                  <span
+                    v-if="draftAutoFilled.location"
+                    class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700"
+                    >자동</span
+                  >
                 </label>
-                <input v-model="editing.location" placeholder="예: 본동 3층 슬라브"
+                <input
+                  v-model="editing.location"
+                  placeholder="예: 본동 3층 슬라브"
                   @input="clearDraftHighlight('location')"
                   class="w-full rounded-md border bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400"
-                  :class="draftAutoFilled.location ? 'border-flare-300' : 'border-forena-200'" />
+                  :class="draftAutoFilled.location ? 'border-flare-300' : 'border-forena-200'"
+                />
               </div>
             </div>
 
-            <!-- ===== 중장비 + 게이트 배정 ===== -->
             <div class="mt-5 rounded-xl border border-forena-100 bg-forena-50/30 p-4">
               <div class="mb-2 flex items-center justify-between">
                 <p class="flex items-center gap-1.5 text-[11px] font-bold text-forena-700">
                   <Truck class="h-3.5 w-3.5 text-flare-600" />
                   필요 중장비 + 게이트 배정 ({{ editing.equipment.length }})
-                  <span v-if="draftAutoFilled.equipment" class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700">자동 입력됨</span>
+                  <span
+                    v-if="draftAutoFilled.equipment"
+                    class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700"
+                    >자동 입력됨</span
+                  >
                 </p>
               </div>
 
-              <!-- 입력 행 -->
-              <div class="grid grid-cols-2 gap-2 rounded-lg bg-white p-3 ring-1 ring-forena-100 sm:grid-cols-5">
+              <div
+                class="grid grid-cols-2 gap-2 rounded-lg bg-white p-3 ring-1 ring-forena-100 sm:grid-cols-5"
+              >
                 <div class="sm:col-span-2">
                   <label class="mb-1 block text-[10px] font-bold text-forena-500">장비명</label>
-                  <select v-model="editing.equipmentInput.name"
-                    class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm">
+                  <select
+                    v-model="editing.equipmentInput.name"
+                    class="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+                  >
                     <option value="">장비 선택</option>
-                    <optgroup v-for="(items, category) in equipmentList" :key="category" :label="category">
-                      <option v-for="equipment in items" :key="`${category}_${equipment}`" :value="equipment">
+                    <optgroup
+                      v-for="(items, category) in equipmentList"
+                      :key="category"
+                      :label="category"
+                    >
+                      <option
+                        v-for="equipment in items"
+                        :key="`${category}_${equipment}`"
+                        :value="equipment"
+                      >
                         {{ equipment }}
                       </option>
                     </optgroup>
@@ -919,47 +1281,82 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
                 </div>
                 <div>
                   <label class="mb-1 block text-[10px] font-bold text-forena-500">대수</label>
-                  <input type="number" min="1" v-model.number="editing.equipmentInput.count"
-                    class="w-full rounded-md border border-forena-200 px-2 py-1.5 text-xs tabular-nums outline-none focus:border-flare-400" />
+                  <input
+                    type="number"
+                    min="1"
+                    v-model.number="editing.equipmentInput.count"
+                    class="w-full rounded-md border border-forena-200 px-2 py-1.5 text-xs tabular-nums outline-none focus:border-flare-400"
+                  />
                 </div>
-                <div>
-                  <label class="mb-1 block text-[10px] font-bold text-forena-500">입차 게이트</label>
-                  <select v-model="editing.equipmentInput.gateIn"
-                    class="w-full rounded-md border border-forena-200 px-2 py-1.5 text-xs outline-none focus:border-flare-400">
-                    <option v-for="g in GATES" :key="g.id" :value="g.id">{{ g.name }}</option>
+                <div class="flex-1">
+                  <label class="block text-xs font-medium text-slate-500 mb-1">입차 게이트</label>
+                  <select
+                    v-model="editing.equipmentInput.gateIn"
+                    class="w-full h-9 px-3 rounded-lg border border-slate-200 text-sm focus:ring-2 focus:ring-flare-500 outline-none"
+                  >
+                    <option value="" disabled>게이트 선택</option>
+                    <!-- feat : GATES 배열을 돌며 동적으로 옵션 생성 -->
+                    <option
+                      v-for="g in GATES"
+                      :key="g.gateIdx"
+                      :value="g.gateIdx"
+                      :class="g.status === '혼잡' ? 'text-rose-500' : 'text-emerald-500'"
+                    >
+                      {{ getGateLabel(g) }}
+                    </option>
                   </select>
                 </div>
-                <div>
-                  <label class="mb-1 block text-[10px] font-bold text-forena-500">출차 게이트</label>
-                  <select v-model="editing.equipmentInput.gateOut"
-                    class="w-full rounded-md border border-forena-200 px-2 py-1.5 text-xs outline-none focus:border-flare-400">
-                    <option v-for="g in GATES" :key="g.id" :value="g.id">{{ g.name }}</option>
+                <div class="flex-1">
+                  <label class="block text-xs font-medium text-slate-500 mb-1">출차 게이트</label>
+                  <select
+                    v-model="editing.equipmentInput.gateOut"
+                    class="w-full h-9 px-3 rounded-lg border border-slate-200 text-sm focus:ring-2 focus:ring-flare-500 outline-none"
+                  >
+                    <option value="" disabled>게이트 선택</option>
+                    <option v-for="g in GATES" :key="g.gateIdx" :value="g.gateIdx">
+                      {{ getGateLabel(g) }}
+                    </option>
                   </select>
                 </div>
                 <div class="sm:col-span-5">
-                  <button @click="addEquipment"
-                    class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-100">
+                  <button
+                    @click="addEquipment"
+                    class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-100"
+                  >
                     <Plus class="h-3 w-3" /> 장비 추가
                   </button>
                 </div>
               </div>
 
-              <!-- 등록된 장비 -->
               <div v-if="editing.equipment.length" class="mt-2 space-y-1.5">
-                <div v-for="(eq, i) in editing.equipment" :key="eq.id"
-                  class="flex items-center gap-2 rounded-lg bg-white px-3 py-2 ring-1 ring-forena-100">
+                <div
+                  v-for="(eq, i) in editing.equipment"
+                  :key="eq.id"
+                  class="flex items-center gap-2 rounded-lg bg-white px-3 py-2 ring-1 ring-forena-100"
+                >
                   <Wrench class="h-3.5 w-3.5 text-forena-400" />
                   <span class="font-semibold text-xs text-forena-900">{{ eq.name }}</span>
-                  <span class="rounded-md bg-forena-50 px-1.5 py-0.5 text-[10px] font-bold text-forena-700 tabular-nums">{{ eq.count }}대</span>
+                  <span
+                    class="rounded-md bg-forena-50 px-1.5 py-0.5 text-[10px] font-bold text-forena-700 tabular-nums"
+                    >{{ eq.count }}대</span
+                  >
                   <span class="ml-auto flex items-center gap-1.5 text-[11px]">
-                    <select v-model="eq.gateIn"
-                      class="rounded border border-forena-200 px-1.5 py-0.5 text-[11px] outline-none focus:border-flare-400">
-                      <option v-for="g in GATES" :key="g.id" :value="g.id">입 · {{ g.name }}</option>
+                    <select
+                      v-model="eq.gateIn"
+                      class="rounded border border-forena-200 px-1.5 py-0.5 text-[11px] outline-none focus:border-flare-400"
+                    >
+                      <option v-for="g in GATES" :key="g.id" :value="g.id">
+                        입 · {{ g.name }}
+                      </option>
                     </select>
                     <ArrowRightLeft class="h-3 w-3 text-forena-400" />
-                    <select v-model="eq.gateOut"
-                      class="rounded border border-forena-200 px-1.5 py-0.5 text-[11px] outline-none focus:border-flare-400">
-                      <option v-for="g in GATES" :key="g.id" :value="g.id">출 · {{ g.name }}</option>
+                    <select
+                      v-model="eq.gateOut"
+                      class="rounded border border-forena-200 px-1.5 py-0.5 text-[11px] outline-none focus:border-flare-400"
+                    >
+                      <option v-for="g in GATES" :key="g.id" :value="g.id">
+                        출 · {{ g.name }}
+                      </option>
                     </select>
                   </span>
                   <button @click="removeEquipment(i)" class="text-slate-400 hover:text-rose-600">
@@ -968,21 +1365,33 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
                 </div>
               </div>
 
-              <!-- 게이트 혼잡도 미니 뷰 -->
               <div class="mt-3">
                 <p class="mb-1.5 text-[10px] font-bold uppercase tracking-wide text-forena-500">
                   현재 일자 게이트 혼잡도
                 </p>
                 <div class="grid grid-cols-2 gap-1.5 sm:grid-cols-4">
-                  <div v-for="g in gateAssignment" :key="g.id"
+                  <div
+                    v-for="g in gateAssignment"
+                    :key="g.id"
                     class="rounded-md border px-2 py-1.5"
-                    :class="g.level === 'high' ? 'border-rose-200 bg-rose-50/40'
-                            : g.level === 'mid' ? 'border-amber-200 bg-amber-50/40'
-                            : 'border-forena-100 bg-white'">
+                    :class="
+                      g.level === 'high'
+                        ? 'border-rose-200 bg-rose-50/40'
+                        : g.level === 'mid'
+                          ? 'border-amber-200 bg-amber-50/40'
+                          : 'border-forena-100 bg-white'
+                    "
+                  >
                     <div class="flex items-center justify-between">
                       <span class="text-[11px] font-bold text-forena-800">{{ g.name }}</span>
-                      <span v-if="g.level === 'high'" class="text-[9px] font-bold text-rose-600">과밀</span>
-                      <span v-else-if="g.level === 'mid'" class="text-[9px] font-bold text-amber-600">혼잡</span>
+                      <span v-if="g.level === 'high'" class="text-[9px] font-bold text-rose-600"
+                        >과밀</span
+                      >
+                      <span
+                        v-else-if="g.level === 'mid'"
+                        class="text-[9px] font-bold text-amber-600"
+                        >혼잡</span
+                      >
                       <span v-else class="text-[9px] font-bold text-emerald-600">원활</span>
                     </div>
                     <p class="mt-0.5 text-[10px] tabular-nums text-forena-500">
@@ -993,57 +1402,93 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
               </div>
             </div>
 
-            <!-- ===== 작업 상세 ===== -->
             <div class="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2">
               <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
+                <label
+                  class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
+                >
                   작업 상세 내역 <span class="text-rose-500">*</span>
-                  <span v-if="draftAutoFilled.workDetail" class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700">자동</span>
+                  <span
+                    v-if="draftAutoFilled.workDetail"
+                    class="ml-1 rounded bg-flare-100 px-1 text-[9px] font-bold text-flare-700"
+                    >자동</span
+                  >
                 </label>
-                <textarea v-model="editing.workDetail" rows="5"
+                <textarea
+                  v-model="editing.workDetail"
+                  rows="5"
                   @input="clearDraftHighlight('workDetail')"
                   placeholder="작업 절차, 범위, 협의사항 등"
                   class="w-full resize-none rounded-md border bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"
-                  :class="draftAutoFilled.workDetail ? 'border-flare-300' : 'border-forena-200'"></textarea>
+                  :class="draftAutoFilled.workDetail ? 'border-flare-300' : 'border-forena-200'"
+                ></textarea>
               </div>
               <div>
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">안전 유의사항</label>
-                <textarea v-model="editing.safety" rows="5"
+                <label
+                  class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
+                  >안전 유의사항</label
+                >
+                <textarea
+                  v-model="editing.safety"
+                  rows="5"
                   placeholder="추락/낙하/화재 등 위험요인 및 안전조치"
-                  class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"></textarea>
+                  class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"
+                ></textarea>
               </div>
               <div class="md:col-span-2">
-                <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">특이사항</label>
-                <textarea v-model="editing.notes" rows="2"
+                <label
+                  class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
+                  >특이사항</label
+                >
+                <textarea
+                  v-model="editing.notes"
+                  rows="2"
                   placeholder="기상, 선행공정 의존성, 추가 요청 등"
-                  class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"></textarea>
+                  class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"
+                ></textarea>
               </div>
             </div>
 
-            <!-- ===== 사진 첨부 ===== -->
             <div class="mt-5 rounded-xl border border-forena-100 bg-forena-50/30 p-3.5">
               <div class="mb-2 flex items-center justify-between">
                 <p class="flex items-center gap-1.5 text-[11px] font-bold text-forena-700">
                   <ImageIcon class="h-3.5 w-3.5 text-flare-600" />
                   현장 / 도면 사진 ({{ editing.photos.length }})
                 </p>
-                <button @click="pickPhotos"
-                  class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-100">
+                <button
+                  @click="pickPhotos"
+                  class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-100"
+                >
                   <Plus class="h-3 w-3" /> 사진 추가
                 </button>
-                <input ref="photoInputRef" type="file" class="sr-only"
-                  accept="image/*" multiple @change="onPhotoChange" />
+                <input
+                  ref="photoInputRef"
+                  type="file"
+                  class="sr-only"
+                  accept="image/*"
+                  multiple
+                  @change="onPhotoChange"
+                />
               </div>
-              <div v-if="editing.photos.length"
-                class="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5">
-                <div v-for="(photo, i) in editing.photos" :key="photo.id"
-                  class="group relative aspect-square overflow-hidden rounded-lg border border-forena-200 bg-white">
+              <div
+                v-if="editing.photos.length"
+                class="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5"
+              >
+                <div
+                  v-for="(photo, i) in editing.photos"
+                  :key="photo.id"
+                  class="group relative aspect-square overflow-hidden rounded-lg border border-forena-200 bg-white"
+                >
                   <img :src="photo.dataUrl" :alt="photo.name" class="h-full w-full object-cover" />
-                  <button @click="removePhoto(i)"
-                    class="absolute right-1 top-1 rounded-md bg-slate-900/70 p-1 text-white opacity-0 transition group-hover:opacity-100 hover:bg-rose-600">
+                  <button
+                    @click="removePhoto(i)"
+                    class="absolute right-1 top-1 rounded-md bg-slate-900/70 p-1 text-white opacity-0 transition group-hover:opacity-100 hover:bg-rose-600"
+                  >
                     <Trash2 class="h-3 w-3" />
                   </button>
-                  <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-slate-900/70 to-transparent px-1.5 py-1">
+                  <div
+                    class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-slate-900/70 to-transparent px-1.5 py-1"
+                  >
                     <p class="truncate text-[9px] font-semibold text-white">{{ photo.name }}</p>
                   </div>
                 </div>
@@ -1051,27 +1496,44 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
               <p v-else class="text-[11px] text-slate-400">첨부된 사진이 없습니다.</p>
             </div>
 
-            <!-- ===== 일반 첨부 파일 ===== -->
             <div class="mt-3 rounded-xl border border-forena-100 bg-forena-50/30 p-3.5">
               <div class="mb-2 flex items-center justify-between">
                 <p class="flex items-center gap-1.5 text-[11px] font-bold text-forena-700">
                   <Paperclip class="h-3.5 w-3.5 text-flare-600" />
                   첨부 파일 ({{ editing.files.length }})
-                  <span class="ml-1 text-[10px] font-normal text-forena-400">PDF · Excel · 이미지</span>
+                  <span class="ml-1 text-[10px] font-normal text-forena-400"
+                    >PDF · Excel · 이미지</span
+                  >
                 </p>
-                <button @click="pickFiles"
-                  class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-100">
+                <button
+                  @click="pickFiles"
+                  class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-[11px] font-bold text-flare-700 hover:bg-flare-100"
+                >
                   <Plus class="h-3 w-3" /> 파일 추가
                 </button>
-                <input ref="fileInputRef" type="file" class="sr-only"
-                  accept=".pdf,.xls,.xlsx,.csv,image/*" multiple @change="onFileChangeInput" />
+                <input
+                  ref="fileInputRef"
+                  type="file"
+                  class="sr-only"
+                  accept=".pdf,.xls,.xlsx,.csv,image/*"
+                  multiple
+                  @change="onFileChangeInput"
+                />
               </div>
               <ul v-if="editing.files.length" class="space-y-1.5">
-                <li v-for="(f, i) in editing.files" :key="f.id"
-                  class="flex items-center gap-2 rounded-lg bg-white px-2.5 py-2 ring-1 ring-forena-100">
-                  <span class="rounded-md bg-flare-50 px-1.5 py-0.5 text-[9px] font-bold text-flare-700">{{ fileBadge(f.type) }}</span>
+                <li
+                  v-for="(f, i) in editing.files"
+                  :key="f.id"
+                  class="flex items-center gap-2 rounded-lg bg-white px-2.5 py-2 ring-1 ring-forena-100"
+                >
+                  <span
+                    class="rounded-md bg-flare-50 px-1.5 py-0.5 text-[9px] font-bold text-flare-700"
+                    >{{ fileBadge(f.type) }}</span
+                  >
                   <span class="flex-1 truncate text-xs text-forena-800">{{ f.name }}</span>
-                  <span class="shrink-0 text-[10px] text-forena-400 tabular-nums">{{ fmtSize(f.size) }}</span>
+                  <span class="shrink-0 text-[10px] text-forena-400 tabular-nums">{{
+                    fmtSize(f.size)
+                  }}</span>
                   <button @click="removeFile(i)" class="text-slate-400 hover:text-rose-600">
                     <Trash2 class="h-3.5 w-3.5" />
                   </button>
@@ -1081,22 +1543,29 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
             </div>
           </div>
 
-          <!-- 푸터 -->
-          <div class="flex shrink-0 items-center justify-between gap-2 border-t border-forena-100 bg-forena-50/40 px-6 py-3">
+          <div
+            class="flex shrink-0 items-center justify-between gap-2 border-t border-forena-100 bg-forena-50/40 px-6 py-3"
+          >
             <p class="text-[11px] text-forena-500">
               <span class="text-rose-500">*</span> 표시는 필수 입력 항목입니다.
             </p>
             <div class="flex gap-2">
-              <button @click="closeEditor"
-                class="rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-semibold text-forena-700 hover:bg-forena-50">
+              <button
+                @click="closeEditor"
+                class="rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-semibold text-forena-700 hover:bg-forena-50"
+              >
                 취소
               </button>
-              <button @click="saveDraft"
-                class="inline-flex items-center gap-1.5 rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-bold text-forena-700 hover:bg-forena-50">
+              <button
+                @click="saveDraft"
+                class="inline-flex items-center gap-1.5 rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-bold text-forena-700 hover:bg-forena-50"
+              >
                 <Save class="h-3.5 w-3.5" /> 임시 저장
               </button>
-              <button @click="submitOrder"
-                class="inline-flex items-center gap-1.5 rounded-lg bg-flare-500 px-4 py-2 text-xs font-bold text-white shadow-sm hover:bg-flare-600">
+              <button
+                @click="submitOrder"
+                class="inline-flex items-center gap-1.5 rounded-lg bg-flare-500 px-4 py-2 text-xs font-bold text-white shadow-sm hover:bg-flare-600"
+              >
                 <Send class="h-3.5 w-3.5" /> 제출
               </button>
             </div>
@@ -1105,26 +1574,33 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
       </div>
     </transition>
 
-    <!-- =====================================================
-         상세 보기 모달 (이미지 디자인 톤 반영)
-         ===================================================== -->
     <transition
       enter-active-class="transition duration-150 ease-out"
       enter-from-class="opacity-0"
       enter-to-class="opacity-100"
       leave-active-class="transition duration-100 ease-in"
       leave-from-class="opacity-100"
-      leave-to-class="opacity-0">
-      <div v-if="viewing"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="viewing"
         class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 p-4"
-        @click.self="closeViewer">
-        <div class="flex max-h-[94vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl">
-          <!-- 헤더 (이미지 톤: 작업 상세 + 연필) -->
-          <div class="flex shrink-0 items-center justify-between border-b border-forena-100 px-6 py-4">
+        @click.self="closeViewer"
+      >
+        <div
+          class="flex max-h-[94vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl"
+        >
+          <div
+            class="flex shrink-0 items-center justify-between border-b border-forena-100 px-6 py-4"
+          >
             <p class="text-sm font-bold text-forena-900">작업 상세</p>
             <div class="flex items-center gap-1">
-              <button v-if="canEdit(viewing)" @click="openEdit(viewing); closeViewer()"
-                class="rounded-md p-1.5 text-forena-500 hover:bg-forena-50 hover:text-forena-800" title="수정">
+              <button
+                v-if="canEdit(viewing)"
+                @click="editViewing"
+                class="rounded-md p-1.5 text-forena-500 hover:bg-forena-50 hover:text-forena-800"
+                title="수정"
+              >
                 <Pencil class="h-4 w-4" />
               </button>
               <button @click="closeViewer" class="text-slate-400 hover:text-forena-700">
@@ -1133,147 +1609,212 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
             </div>
           </div>
 
-          <!-- 본문 -->
           <div class="min-h-0 flex-1 overflow-y-auto px-6 py-4">
-            <!-- 타이틀 영역 -->
             <div class="flex items-start gap-2">
               <h2 class="text-lg font-bold text-forena-900">{{ viewing.location }}</h2>
-              <span class="mt-1.5 rounded-md bg-forena-100 px-1.5 py-0.5 text-[10px] font-bold text-forena-700">{{ viewing.process }}</span>
+              <span
+                class="mt-1.5 rounded-md bg-forena-100 px-1.5 py-0.5 text-[10px] font-bold text-forena-700"
+                >{{ viewing.process }}</span
+              >
             </div>
             <p class="mt-0.5 font-mono text-xs text-forena-500">{{ viewing.id }}</p>
 
-            <!-- 상태 배지 줄 -->
             <div class="mt-2 flex flex-wrap gap-1.5">
-              <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold ring-1"
-                :class="statusMeta(viewing.status).cls">
+              <span
+                class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-bold ring-1"
+                :class="statusMeta(viewing.status).cls"
+              >
                 <component :is="statusMeta(viewing.status).icon" class="h-3 w-3" />
                 {{ viewing.status }}
               </span>
-              <span class="rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-bold text-emerald-700 ring-1 ring-emerald-200">
+              <span
+                class="rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-bold text-emerald-700 ring-1 ring-emerald-200"
+              >
                 {{ viewing.partner }}
               </span>
             </div>
 
-            <!-- 그리드 정보 박스 -->
             <div class="mt-4 grid grid-cols-1 gap-2.5 sm:grid-cols-2">
               <div class="rounded-xl border border-forena-100 bg-forena-50/40 px-4 py-3">
-                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">작업 위치</p>
+                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">
+                  작업 위치
+                </p>
                 <p class="mt-1 flex items-center gap-1 text-sm font-bold text-forena-900">
                   <MapPin class="h-3.5 w-3.5 text-flare-600" />{{ viewing.location }}
                 </p>
               </div>
               <div class="rounded-xl border border-forena-100 bg-forena-50/40 px-4 py-3">
-                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">작업 시간</p>
-                <p class="mt-1 text-sm font-bold tabular-nums text-forena-900">{{ viewing.workTime }}</p>
+                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">
+                  작업 시간
+                </p>
+                <p class="mt-1 text-sm font-bold tabular-nums text-forena-900">
+                  {{ viewing.workTime }}
+                </p>
               </div>
               <div class="rounded-xl border border-forena-100 bg-forena-50/40 px-4 py-3">
-                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">필요 인원</p>
+                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">
+                  필요 인원
+                </p>
                 <p class="mt-1 text-2xl font-bold tabular-nums text-forena-900">
-                  {{ viewing.workers }}<span class="text-sm font-normal text-slate-400 ml-1">명</span>
+                  {{ viewing.workers
+                  }}<span class="text-sm font-normal text-slate-400 ml-1">명</span>
                 </p>
               </div>
               <div class="rounded-xl border border-rose-200 bg-rose-50/40 px-4 py-3">
-                <p class="text-[10px] font-bold uppercase tracking-wide text-rose-600">작성자 / 작성일</p>
+                <p class="text-[10px] font-bold uppercase tracking-wide text-rose-600">
+                  작성자 / 작성일
+                </p>
                 <p class="mt-1 text-sm font-bold text-rose-700">
-                  {{ viewing.author }}<span class="ml-1 text-[11px] font-normal text-rose-500">{{ viewing.createdAt }}</span>
+                  {{ viewing.author
+                  }}<span class="ml-1 text-[11px] font-normal text-rose-500">{{
+                    viewing.createdAt
+                  }}</span>
                 </p>
               </div>
             </div>
 
-            <!-- 필요 장비 + 게이트 -->
             <div class="mt-3 rounded-xl border border-forena-100 px-4 py-3">
               <div class="flex items-center justify-between">
-                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-500">필요 장비 + 게이트</p>
-                <span v-if="viewing.equipment.length"
-                  class="text-[10px] font-bold text-emerald-700">배정 완료</span>
+                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-500">
+                  필요 장비 + 게이트
+                </p>
+                <span v-if="viewing.equipment.length" class="text-[10px] font-bold text-emerald-700"
+                  >배정 완료</span
+                >
               </div>
               <div v-if="viewing.equipment.length" class="mt-2 space-y-1.5">
-                <div v-for="eq in viewing.equipment" :key="eq.id"
-                  class="flex flex-wrap items-center gap-2 rounded-lg bg-forena-50/60 px-3 py-1.5">
+                <div
+                  v-for="eq in viewing.equipment"
+                  :key="eq.id"
+                  class="flex flex-wrap items-center gap-2 rounded-lg bg-forena-50/60 px-3 py-1.5"
+                >
                   <Wrench class="h-3.5 w-3.5 text-forena-500" />
-                  <span class="text-xs font-semibold text-forena-900">{{ eq.name }} {{ eq.count }}대</span>
+                  <span class="text-xs font-semibold text-forena-900"
+                    >{{ eq.name }} {{ eq.count }}대</span
+                  >
                   <span class="ml-auto inline-flex items-center gap-1 text-[11px] text-forena-700">
-                    <span class="rounded bg-emerald-100 px-1.5 py-0.5 font-bold text-emerald-700">입 · {{ gateName(eq.gateIn) }}</span>
+                    <span class="rounded bg-emerald-100 px-1.5 py-0.5 font-bold text-emerald-700"
+                      >입 · {{ gateName(eq.gateIn) }}</span
+                    >
                     <ArrowRightLeft class="h-3 w-3 text-forena-400" />
-                    <span class="rounded bg-rose-100 px-1.5 py-0.5 font-bold text-rose-700">출 · {{ gateName(eq.gateOut) }}</span>
+                    <span class="rounded bg-rose-100 px-1.5 py-0.5 font-bold text-rose-700"
+                      >출 · {{ gateName(eq.gateOut) }}</span
+                    >
                   </span>
                 </div>
               </div>
               <p v-else class="mt-1 text-xs text-slate-400">투입 장비 없음</p>
             </div>
 
-            <!-- 작업 상세 -->
             <div class="mt-3 rounded-xl border border-forena-100 px-4 py-3">
-              <p class="text-[10px] font-bold uppercase tracking-wide text-forena-500">작업 상세 내역</p>
+              <p class="text-[10px] font-bold uppercase tracking-wide text-forena-500">
+                작업 상세 내역
+              </p>
               <p class="mt-1 text-xs leading-relaxed text-forena-800">{{ viewing.workDetail }}</p>
             </div>
 
-            <!-- 안전 (이미지의 노란 박스 톤) -->
-            <div v-if="viewing.safety" class="mt-3 rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-3">
-              <p class="text-[10px] font-bold uppercase tracking-wide text-amber-700">안전 유의사항</p>
+            <div
+              v-if="viewing.safety"
+              class="mt-3 rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-3"
+            >
+              <p class="text-[10px] font-bold uppercase tracking-wide text-amber-700">
+                안전 유의사항
+              </p>
               <p class="mt-1 text-xs leading-relaxed text-amber-900">{{ viewing.safety }}</p>
             </div>
 
-            <!-- 특이사항 -->
             <div v-if="viewing.notes" class="mt-3 rounded-xl border border-forena-100 px-4 py-3">
               <p class="text-[10px] font-bold uppercase tracking-wide text-forena-500">특이사항</p>
               <p class="mt-1 text-xs leading-relaxed text-forena-800">{{ viewing.notes }}</p>
             </div>
 
-            <!-- 관련 문서 -->
-            <div v-if="viewing.files?.length" class="mt-3 rounded-xl border border-forena-100 px-4 py-3">
+            <div
+              v-if="viewing.files?.length"
+              class="mt-3 rounded-xl border border-forena-100 px-4 py-3"
+            >
               <p class="text-[10px] font-bold uppercase tracking-wide text-forena-500">관련 문서</p>
               <ul class="mt-1.5 space-y-1">
-                <li v-for="f in viewing.files" :key="f.id"
-                  class="flex items-center gap-2 text-xs text-forena-800">
+                <li
+                  v-for="f in viewing.files"
+                  :key="f.id"
+                  class="flex items-center gap-2 text-xs text-forena-800"
+                >
                   <FileText class="h-3.5 w-3.5 text-forena-400" />
                   <span class="flex-1 truncate">{{ f.name }}</span>
-                  <span class="text-[10px] text-forena-400 tabular-nums">{{ fmtSize(f.size) }}</span>
-                  <button class="rounded p-1 text-forena-400 hover:bg-forena-50 hover:text-forena-700">
+                  <span class="text-[10px] text-forena-400 tabular-nums">{{
+                    fmtSize(f.size)
+                  }}</span>
+                  <button
+                    class="rounded p-1 text-forena-400 hover:bg-forena-50 hover:text-forena-700"
+                  >
                     <Eye class="h-3.5 w-3.5" />
                   </button>
                 </li>
               </ul>
             </div>
 
-            <!-- 사진 -->
-            <div v-if="viewing.photos?.length" class="mt-3 rounded-xl border border-forena-100 px-4 py-3">
+            <div
+              v-if="viewing.photos?.length"
+              class="mt-3 rounded-xl border border-forena-100 px-4 py-3"
+            >
               <p class="text-[10px] font-bold uppercase tracking-wide text-forena-500">현장 사진</p>
               <div class="mt-2 grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5">
-                <div v-for="photo in viewing.photos" :key="photo.id"
-                  class="aspect-square overflow-hidden rounded-lg border border-forena-200 bg-white">
+                <div
+                  v-for="photo in viewing.photos"
+                  :key="photo.id"
+                  class="aspect-square overflow-hidden rounded-lg border border-forena-200 bg-white"
+                >
                   <img :src="photo.dataUrl" :alt="photo.name" class="h-full w-full object-cover" />
                 </div>
               </div>
             </div>
 
-            <!-- 상태 이력 -->
-            <div v-if="viewing.history?.length" class="mt-3 rounded-xl border border-forena-100 px-4 py-3">
+            <div
+              v-if="viewing.history?.length"
+              class="mt-3 rounded-xl border border-forena-100 px-4 py-3"
+            >
               <p class="text-[10px] font-bold uppercase tracking-wide text-forena-500">상태 이력</p>
               <ul class="mt-1.5 space-y-1">
-                <li v-for="(h, i) in viewing.history" :key="i" class="flex items-center gap-2 text-[11px]">
+                <li
+                  v-for="(h, i) in viewing.history"
+                  :key="i"
+                  class="flex items-center gap-2 text-[11px]"
+                >
                   <span class="font-mono text-forena-400 tabular-nums">{{ h.at }}</span>
                   <span class="text-forena-700">{{ h.who }}</span>
-                  <span class="rounded bg-forena-50 px-1.5 py-0.5 font-bold text-forena-700">{{ h.what }}</span>
+                  <span class="rounded bg-forena-50 px-1.5 py-0.5 font-bold text-forena-700">{{
+                    h.what
+                  }}</span>
                 </li>
               </ul>
             </div>
           </div>
 
-          <!-- 푸터 액션 (이미지 톤: 빨강 보더 액션 + 진한 메인 액션) -->
-          <div class="flex shrink-0 items-center justify-end gap-2 border-t border-forena-100 bg-white px-6 py-3">
-            <button v-if="currentRole === ROLES.MANAGER && ['승인 대기','검토 중'].includes(viewing.status)"
+          <div
+            class="flex shrink-0 items-center justify-end gap-2 border-t border-forena-100 bg-white px-6 py-3"
+          >
+            <button
+              v-if="
+                currentRole === ROLES.MANAGER && ['승인 대기', '검토 중'].includes(viewing.status)
+              "
               @click="reject"
-              class="inline-flex items-center gap-1.5 rounded-lg border border-rose-200 bg-white px-4 py-2 text-xs font-bold text-rose-700 hover:bg-rose-50">
+              class="inline-flex items-center gap-1.5 rounded-lg border border-rose-200 bg-white px-4 py-2 text-xs font-bold text-rose-700 hover:bg-rose-50"
+            >
               <AlertTriangle class="h-3.5 w-3.5" /> 반려
             </button>
-            <button v-if="currentRole === ROLES.MANAGER && ['승인 대기','검토 중'].includes(viewing.status)"
+            <button
+              v-if="
+                currentRole === ROLES.MANAGER && ['승인 대기', '검토 중'].includes(viewing.status)
+              "
               @click="approve"
-              class="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-4 py-2 text-xs font-bold text-white shadow-sm hover:bg-emerald-600">
+              class="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-4 py-2 text-xs font-bold text-white shadow-sm hover:bg-emerald-600"
+            >
               <CheckCircle2 class="h-3.5 w-3.5" /> 승인
             </button>
-            <button @click="closeViewer"
-              class="rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-semibold text-forena-700 hover:bg-forena-50">
+            <button
+              @click="closeViewer"
+              class="rounded-lg border border-forena-200 bg-white px-4 py-2 text-xs font-semibold text-forena-700 hover:bg-forena-50"
+            >
               닫기
             </button>
           </div>

--- a/src/views/schedule/WorkPlanView.vue
+++ b/src/views/schedule/WorkPlanView.vue
@@ -20,11 +20,15 @@ import {
   Save,
 } from 'lucide-vue-next'
 import { planStore } from '@/data/planStore'
-import { fetchWorkPlanList, submitWeeklyWorkPlan } from '@/api/workplan.js'
+import { fetchTradeProcessList } from '@/api/tradeProcess.js'
+import { fetchWorkPlanList, submitWeeklyWorkPlan, createWorkPlan } from '@/api/workplan.js'
+
+const selectedProjectId = ref(1)
 
 const weeklyPlans = ref([]) // 주간 작업 계획
 const monthlyPlans = ref([]) // 월간 작업 계획
 const annualPlans = ref([]) // 연간 작업 계획
+const baselinePlans = ref([]) // 최초 공정표 기반 기준 공정
 const loading = ref(false)
 const viewMode = ref('weekly')
 const filterTrade = ref('')
@@ -380,13 +384,45 @@ function fixVerifyRow(row) {
 function removeVerifyRow(row) {
   verifyRows.value = verifyRows.value.filter((r) => r.id !== row.id)
 }
-function confirmVerifyAndApply() {
-  // TODO: 백엔드 일괄 저장 API 연동 예정
-  //   await createWorkPlanBulk({ planType: verifyCategory.value, rows: verifyRows.value })
-  //   await loadPlans()
-  // 현재는 데모로 알림만 표시 (파일 파싱 + 일괄 저장 API는 추후 구현)
-  showVerifyModal.value = false
-  alert(`${verifyCategory.value} 계획서 ${verifyRows.value.length}건이 간트차트에 반영되었습니다.`)
+async function confirmVerifyAndApply() {
+  const validRows = verifyRows.value.filter((row) => row.name && row.trade && row.start && row.end)
+
+  if (!validRows.length) {
+    alert('저장할 수 있는 작업이 없습니다.')
+    return
+  }
+
+  try {
+    await Promise.all(
+      validRows.map((row) =>
+        createWorkPlan({
+          name: row.name,
+          trade: row.trade,
+          location: row.location,
+          planType: verifyCategory.value, // '연간' 또는 '월간'
+          status: '진행 예정',
+          start: row.start,
+          end: row.end,
+          requiredCount: 0,
+          workers: [],
+          equipment: [],
+          partner: '',
+          manager: '',
+          contact: '',
+          weekStart: '',
+          note: '',
+        }),
+      ),
+    )
+
+    showVerifyModal.value = false
+    alert(`${verifyCategory.value} 계획서 ${validRows.length}건이 저장되었습니다.`)
+
+    await loadPlans()
+  } catch (err) {
+    console.error(`${verifyCategory.value} 계획서 저장 실패:`, err)
+    alert(err.message || '계획서 저장에 실패했습니다.')
+  }
 }
 function cancelVerify() {
   showVerifyModal.value = false
@@ -446,31 +482,84 @@ const EQUIPMENT_GROUPS = [
 const showWeeklyForm = ref(false)
 const weeklyForm = ref(null) // { partner, manager, weekStart, items: [...] }
 
+const monthlyPlanOptions = computed(() => {
+  return monthlyPlans.value.map((p) => ({
+    id: p.id,
+    label: `${p.name} / ${p.location || '-'} / ${p.start} ~ ${p.end}`,
+    raw: p,
+  }))
+})
+
 function openWeeklyForm() {
   // 이번 주 시작일(일요일 기준)
   const t = new Date()
   const ws = new Date(t)
   ws.setDate(t.getDate() - t.getDay())
+
+  const weekStart = ws.toISOString().slice(0, 10)
+
   weeklyForm.value = {
+    // 선택한 월간 계획 정보
+    monthlyPlanId: null,
+    monthlyPlanName: '',
+    tradeProcessId: null,
+    trade: '',
+    monthlyStart: '',
+    monthlyEnd: '',
+    monthlyLocation: '',
+
+    // 주간 계획서 공통 정보
     partner: '',
     manager: '',
     contact: '',
-    weekStart: ws.toISOString().slice(0, 10),
-    items: [makeWeeklyItem(ws.toISOString().slice(0, 10))],
+    weekStart,
+
+    // 일자별 작업
+    items: [makeWeeklyItem(weekStart)],
   }
+
   showWeeklyForm.value = true
 }
 
-function makeWeeklyItem(date) {
+function makeWeeklyItem(date, defaults = {}) {
   return {
     id: `wi_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
     date,
-    processName: '', // 공정명 (필수)
-    zone: '', // 작업구역 (필수)
-    workers: [makeWorkerEntry()], // 인력 (필수) - [{ tradeId, trade, count }]
-    equipment: [makeEquipmentEntry()], // 장비 (필수) - [{ equipId, type, count }]
+    processName: defaults.processName || '',
+    zone: defaults.zone || '',
+    workers: [makeWorkerEntry()],
+    equipment: [makeEquipmentEntry()],
     note: '',
   }
+}
+function onSelectMonthlyPlan() {
+  if (!weeklyForm.value) return
+
+  const selected = monthlyPlans.value.find(
+    (p) => String(p.id) === String(weeklyForm.value.monthlyPlanId),
+  )
+
+  if (!selected) return
+
+  weeklyForm.value.monthlyPlanName = selected.name || ''
+  weeklyForm.value.tradeProcessId = selected.tradeProcessId || null
+  weeklyForm.value.trade = selected.trade || ''
+  weeklyForm.value.monthlyStart = selected.start || ''
+  weeklyForm.value.monthlyEnd = selected.end || ''
+  weeklyForm.value.monthlyLocation = selected.location || ''
+
+  weeklyForm.value.partner = selected.partner || ''
+  weeklyForm.value.manager = selected.manager || ''
+  weeklyForm.value.contact = selected.contact || ''
+
+  weeklyForm.value.weekStart = selected.start || weeklyForm.value.weekStart
+
+  weeklyForm.value.items = [
+    makeWeeklyItem(selected.start || weeklyForm.value.weekStart, {
+      processName: selected.name || '',
+      zone: selected.location || '',
+    }),
+  ]
 }
 
 function makeWorkerEntry() {
@@ -520,8 +609,19 @@ function itemEquipmentTotal(item) {
 }
 
 function addWeeklyItem() {
-  weeklyForm.value.items.push(makeWeeklyItem(weeklyForm.value.weekStart))
+  if (!weeklyForm.value) return
+
+  const lastDate = weeklyForm.value.items.at(-1)?.date
+  const baseDate = lastDate || weeklyForm.value.weekStart
+
+  weeklyForm.value.items.push(
+    makeWeeklyItem(baseDate, {
+      processName: weeklyForm.value.monthlyPlanName,
+      zone: weeklyForm.value.monthlyLocation,
+    }),
+  )
 }
+
 function removeWeeklyItem(idx) {
   if (weeklyForm.value.items.length <= 1) return
   weeklyForm.value.items.splice(idx, 1)
@@ -529,8 +629,12 @@ function removeWeeklyItem(idx) {
 
 const weeklyFormValid = computed(() => {
   if (!weeklyForm.value) return false
+
   const w = weeklyForm.value
+
+  if (!w.monthlyPlanId) return false
   if (!w.partner.trim() || !w.manager.trim()) return false
+
   return w.items.every(
     (it) =>
       it.date &&
@@ -552,15 +656,21 @@ async function submitWeeklyForm() {
   try {
     // 백엔드 WeeklySubmitReq 형식으로 매핑
     const payload = {
+      // 선택한 월간 계획이 주간 계획의 부모가 됨
+      parentWorkPlanId: w.monthlyPlanId,
+
+      // 기준 공정 연결
+      tradeProcessId: w.tradeProcessId,
+
       partner: w.partner,
       manager: w.manager,
       contact: w.contact,
       weekStart: w.weekStart,
+
       items: w.items.map((it) => ({
         date: it.date,
         processName: it.processName,
         zone: it.zone,
-        // tradeId/equipId는 클라이언트 키이므로 제외
         workers: it.workers.map((wk) => ({
           trade: wk.trade,
           count: Number(wk.count) || 0,
@@ -596,30 +706,25 @@ function handleClickOutside(e) {
 
 // 작업 계획 목록 로드 (주간 + 월간 + 연간 동시 호출)
 async function loadPlans() {
-  loading.value = true
   try {
-    const params = {}
-    if (filterTrade.value) params.trade = filterTrade.value
-    const [weeklyRes, monthlyRes, yearlyRes] = await Promise.all([
-      fetchWorkPlanList({ ...params, planType: '주간' }),
-      fetchWorkPlanList({ ...params, planType: '월간' }),
-      fetchWorkPlanList({ ...params, planType: '연간' }),
+    loading.value = true
+
+    const projectId = selectedProjectId.value || 1
+
+    const [baselineRes, weeklyRes, monthlyRes, yearlyRes] = await Promise.all([
+      fetchTradeProcessList({ projectId }),
+      fetchWorkPlanList({ planType: '주간' }),
+      fetchWorkPlanList({ planType: '월간' }),
+      fetchWorkPlanList({ planType: '연간' }),
     ])
 
+    baselinePlans.value = baselineRes
     weeklyPlans.value = weeklyRes
     monthlyPlans.value = monthlyRes
     annualPlans.value = yearlyRes
-
-    // 백엔드에 저장된 연장 정보를 planStore에 동기화
-    const allPlans = [...weeklyRes, ...monthlyRes, ...yearlyRes]
-    allPlans.forEach((p) => {
-      if (p.extension) {
-        planStore.extensions[p.id] = p.extension
-      }
-    })
   } catch (err) {
-    console.error('작업 계획 조회 실패:', err)
-    alert(err.message || '작업 계획을 불러오지 못했습니다.')
+    console.error('계획 목록 조회 실패:', err)
+    alert(err.message || '계획 목록을 불러오지 못했습니다.')
   } finally {
     loading.value = false
   }
@@ -718,9 +823,46 @@ const isCurrentYear = computed(() => {
 })
 
 // 이번 달과 겹치는 작업 (연장된 종료일까지 고려)
+const monthlyGanttSource = computed(() => {
+  let r = [...baselinePlans.value, ...monthlyPlans.value]
+
+  if (filterTrade.value) {
+    r = r.filter((p) => p.trade === filterTrade.value)
+  }
+
+  if (filterStatus.value) {
+    r = r.filter((p) => workPlanStatus(p) === filterStatus.value)
+  }
+
+  return r
+})
+
+const yearlyGanttSource = computed(() => {
+  let r = [...baselinePlans.value, ...annualPlans.value]
+
+  if (filterTrade.value) {
+    r = r.filter((p) => p.trade === filterTrade.value)
+  }
+
+  if (filterStatus.value) {
+    r = r.filter((p) => workPlanStatus(p) === filterStatus.value)
+  }
+
+  return r
+})
+
 const ganttPlans = computed(() => {
   const { firstDate, lastDate } = monthMeta.value
-  return filtered.value.filter((p) => !(effectiveEnd(p) < firstDate || p.start > lastDate))
+
+  return monthlyGanttSource.value.filter(
+    (p) => !(effectiveEnd(p) < firstDate || p.start > lastDate),
+  )
+})
+
+const yearlyPlans = computed(() => {
+  const { firstDate, lastDate } = yearMeta.value
+
+  return yearlyGanttSource.value.filter((p) => !(effectiveEnd(p) < firstDate || p.start > lastDate))
 })
 
 const yearMeta = computed(() => {
@@ -739,11 +881,6 @@ const yearMeta = computed(() => {
   }
 })
 
-const yearlyPlans = computed(() => {
-  const { firstDate, lastDate } = yearMeta.value
-  return annualFiltered.value.filter((p) => !(effectiveEnd(p) < firstDate || p.start > lastDate))
-})
-
 // 막대 위치/너비 계산 — 이번 달 영역 내로 클리핑
 function barStyle(startStr, endStr) {
   if (!startStr || !endStr) return null
@@ -758,6 +895,14 @@ function barStyle(startStr, endStr) {
     left: `${(sd - 1) * GANTT_DAY_W + 4}px`,
     width: `${span * GANTT_DAY_W - 8}px`,
   }
+}
+
+function monthCellCenterStyle(dateStr) {
+  if (!dateStr) return null
+  const { firstDate, lastDate } = monthMeta.value
+  if (dateStr < firstDate || dateStr > lastDate) return null
+  const day = Number(dateStr.slice(8, 10))
+  return { left: `${(day - 1) * GANTT_DAY_W + GANTT_DAY_W / 2}px` }
 }
 
 function yearBarStyle(startStr, endStr) {
@@ -790,9 +935,58 @@ function actualLineRange(p) {
 
 function progressFillEnd(p) {
   const range = actualLineRange(p)
-  const t = new Date().toISOString().slice(0, 10)
+  const t = formatDateLocal(new Date())
   if (t < range.start) return null
   return t > range.end ? range.end : t
+}
+
+function progressPctOf(p) {
+  const raw = p?.raw || p || {}
+  const value =
+    raw.actualPct ??
+    raw.progressPct ??
+    raw.progress ??
+    raw.processProgress ??
+    raw.actualProgress ??
+    p?.actualPct ??
+    p?.progressPct ??
+    p?.progress ??
+    p?.processProgress ??
+    p?.actualProgress
+  const n = Number(value)
+  return Number.isFinite(n) ? Math.max(0, Math.min(100, n)) : null
+}
+
+function progressBarStyle(p, styleFn) {
+  const full = styleFn(p.start, p.end)
+  if (!full) return { width: '0px' }
+
+  const pct = progressPctOf(p)
+  if (pct != null) return { width: `${pct}%` }
+
+  const fillEnd = progressFillEnd(p)
+  if (!fillEnd) return { width: '0px' }
+
+  const fill = styleFn(p.start, fillEnd)
+  if (!fill) return { width: '0px' }
+
+  const fullLeft = parseFloat(full.left)
+  const fullWidth = parseFloat(full.width)
+  const fillLeft = parseFloat(fill.left)
+  const fillWidth = parseFloat(fill.width)
+  const width = Math.max(0, Math.min(fullWidth, fillLeft + fillWidth - fullLeft))
+
+  return { width: `${width}px` }
+}
+
+function progressDotStyle(p, styleFn) {
+  const widthValue = progressBarStyle(p, styleFn).width
+  const width = widthValue.endsWith('%')
+    ? (parseFloat(widthValue) / 100) * parseFloat(styleFn(p.start, p.end)?.width || 0)
+    : parseFloat(widthValue)
+
+  if (!Number.isFinite(width) || width <= 0) return { display: 'none' }
+  return { left: `${Math.max(0, width - 4)}px` }
 }
 
 // 오늘 라인
@@ -813,6 +1007,395 @@ const extensionCount = computed(() => Object.keys(planStore.extensions).length)
 function selectViewMode(mode) {
   viewMode.value = mode
   selectedPlan.value = null
+}
+
+// =========================
+// 공종 → 공정 → 위치별 실행계획 (3단 그룹핑)
+// =========================
+// trade_process / work_plan 양쪽 응답 형태가 다양할 수 있어
+// 가능한 필드명을 모두 폴백으로 처리한다.
+function baseId(b) {
+  return b.tradeProcessId ?? b.idx ?? b.id ?? null
+}
+function baseTradeName(b) {
+  return b.tradeName ?? b.trade ?? '미분류'
+}
+function baseProcessName(b) {
+  return b.processName ?? b.name ?? '(공정명 없음)'
+}
+function baseStart(b) {
+  return b.plannedStart ?? b.baselineStart ?? b.start ?? null
+}
+function baseEnd(b) {
+  return b.plannedEnd ?? b.baselineEnd ?? b.end ?? null
+}
+function baseWeight(b) {
+  return b.weightPct ?? b.weight ?? null
+}
+function baseIsMilestone(b) {
+  return b.isMilestone ?? b.milestone ?? false
+}
+function workPlanTradeProcessId(w) {
+  return w.tradeProcessId ?? w.trade_process_id ?? w.baseId ?? null
+}
+
+// 공종 그룹핑 공통 함수
+// plans: work_plan 목록 (annual 또는 monthly)
+// returns: [{ group, items: [{ ...baseline, workPlans: [...] }] }]
+function buildGroups(plans) {
+  // 공종 → 공정 맵 구성 (baselinePlans 기준)
+  const tradeMap = new Map()
+
+  for (const b of baselinePlans.value) {
+    if (filterTrade.value && baseTradeName(b) !== filterTrade.value) continue
+
+    const trade = baseTradeName(b)
+    if (!tradeMap.has(trade)) tradeMap.set(trade, [])
+    tradeMap.get(trade).push({
+      id: baseId(b),
+      tradeProcessId: baseId(b),
+      name: baseProcessName(b),
+      trade,
+      weightPct: baseWeight(b),
+      baselineStart: baseStart(b),
+      baselineEnd: baseEnd(b),
+      isMilestone: baseIsMilestone(b),
+      raw: b,
+      workPlans: [],
+    })
+  }
+
+  // 미연결 work_plan 보관용
+  const orphans = []
+
+  // work_plan들을 해당 trade_process에 매칭
+  for (const w of plans) {
+    const tpid = workPlanTradeProcessId(w)
+    if (tpid == null) {
+      console.warn('[WorkPlanView] tradeProcessId 없는 work_plan:', w)
+      orphans.push(w)
+      continue
+    }
+
+    let matched = null
+    for (const arr of tradeMap.values()) {
+      const found = arr.find((it) => String(it.tradeProcessId) === String(tpid))
+      if (found) {
+        matched = found
+        break
+      }
+    }
+    if (!matched) {
+      console.warn('[WorkPlanView] 매칭되는 trade_process 없음:', w)
+      orphans.push(w)
+      continue
+    }
+
+    if (filterStatus.value && workPlanStatus(w) !== filterStatus.value) continue
+
+    matched.workPlans.push({
+      id: w.id,
+      name: w.name,
+      location: w.location || '',
+      start: w.start,
+      end: effectiveEnd(w),
+      status: workPlanStatus(w),
+      raw: w,
+    })
+  }
+
+  // work_plan이 없는 공정은 기준 일정을 기본 실행 일정으로 세팅
+  for (const arr of tradeMap.values()) {
+    for (const item of arr) {
+      if (item.workPlans.length === 0 && item.baselineStart && item.baselineEnd) {
+        item.workPlans.push({
+          id: `__default-${item.id}`,
+          name: item.name,
+          location: '기본 실행 일정',
+          start: item.baselineStart,
+          end: item.baselineEnd,
+          status: '진행 예정',
+          isDefault: true, // 기준 일정에서 복제된 기본값임을 표시
+          raw: null,
+        })
+      }
+    }
+  }
+
+  // 그룹 배열로 변환
+  const groups = []
+  for (const [trade, items] of tradeMap.entries()) {
+    groups.push({ group: trade, items })
+  }
+
+  // 미연결 실행계획 그룹
+  if (orphans.length) {
+    groups.push({
+      group: '미연결 실행계획',
+      isOrphan: true,
+      items: [
+        {
+          id: '__orphan__',
+          tradeProcessId: null,
+          name: '기준 공정에 연결되지 않은 실행계획',
+          trade: '미연결',
+          weightPct: null,
+          baselineStart: null,
+          baselineEnd: null,
+          isMilestone: false,
+          workPlans: orphans.map((w) => ({
+            id: w.id,
+            name: w.name,
+            location: w.location || '',
+            start: w.start,
+            end: effectiveEnd(w),
+            status: workPlanStatus(w),
+            raw: w,
+          })),
+        },
+      ],
+    })
+  }
+
+  return groups
+}
+
+// 월간 work_plan에서 "월간계획서 기준 일정"(파란선) 가져오기
+// 백엔드 스키마 변경 전: plannedStart/plannedEnd 없으면 실행 start/end로 폴백 (두 선이 겹쳐 보임)
+function workPlanPlannedStart(w) {
+  return w.plannedStart ?? w.planned_start ?? w.start ?? null
+}
+function workPlanPlannedEnd(w) {
+  return w.plannedEnd ?? w.planned_end ?? effectiveEnd(w) ?? null
+}
+
+// 연간 work_plan들에서 공정별 "마일스톤 종료일" 계산
+// = 같은 tradeProcessId의 연간 work_plan들 중 가장 늦은 종료일
+function buildProcessMilestones() {
+  const m = new Map() // tradeProcessId -> { date, source }
+  for (const w of annualPlans.value) {
+    const tpid = workPlanTradeProcessId(w)
+    if (tpid == null) continue
+    const end = effectiveEnd(w)
+    if (!end) continue
+    const prev = m.get(tpid)
+    if (!prev || end > prev.date) {
+      m.set(tpid, { date: end, source: w })
+    }
+  }
+  return m
+}
+
+// 월간 전용: 공종 → 공정 → 세부계획(work_plan) 3단 구조
+// 연간 buildGroups와 차이점:
+//  - 공정 행: baseline 막대가 아닌 "마일스톤 점"(연간 빨간선 종료일) 표시
+//  - 세부계획 행: 파란선(월간계획서 기준 plannedStart/End) + 빨간선(실행 start/end)
+function buildMonthlyGroups(plans) {
+  const tradeMap = new Map()
+  const milestones = buildProcessMilestones()
+
+  // 1) baseline(trade_process) 기준으로 공종 → 공정 골격 생성
+  for (const b of baselinePlans.value) {
+    if (filterTrade.value && baseTradeName(b) !== filterTrade.value) continue
+    const trade = baseTradeName(b)
+    const tpid = baseId(b)
+    if (!tradeMap.has(trade)) tradeMap.set(trade, [])
+    const milestone = milestones.get(tpid)
+    tradeMap.get(trade).push({
+      id: tpid,
+      tradeProcessId: tpid,
+      name: baseProcessName(b),
+      trade,
+      weightPct: baseWeight(b),
+      baselineStart: baseStart(b),
+      baselineEnd: baseEnd(b),
+      // 공정 마일스톤: 연간 work_plan의 가장 늦은 종료일 (없으면 baselineEnd)
+      milestoneDate: milestone ? milestone.date : baseEnd(b),
+      milestoneFromAnnual: !!milestone,
+      isMilestone: baseIsMilestone(b),
+      raw: b,
+      details: [], // 세부계획(월간 work_plan)들
+    })
+  }
+
+  // 2) 월간 work_plan들을 세부계획으로 매칭
+  const orphans = []
+  for (const w of plans) {
+    const tpid = workPlanTradeProcessId(w)
+    if (tpid == null) {
+      orphans.push(w)
+      continue
+    }
+    let matched = null
+    for (const arr of tradeMap.values()) {
+      const found = arr.find((it) => it.tradeProcessId === tpid)
+      if (found) {
+        matched = found
+        break
+      }
+    }
+    if (!matched) {
+      orphans.push(w)
+      continue
+    }
+    if (filterStatus.value && workPlanStatus(w) !== filterStatus.value) continue
+
+    matched.details.push({
+      id: w.id,
+      name: w.name || '(세부계획명 없음)',
+      location: w.location || '',
+      // 파란선 = 월간계획서 기준 일정
+      plannedStart: workPlanPlannedStart(w),
+      plannedEnd: workPlanPlannedEnd(w),
+      // 빨간선 = 실행 일정 (주간/지시서/일보로 갱신됨)
+      start: w.start,
+      end: effectiveEnd(w),
+      status: workPlanStatus(w),
+      raw: w,
+    })
+  }
+
+  // 3) 그룹 배열로 변환
+  const groups = []
+  for (const [trade, items] of tradeMap.entries()) {
+    groups.push({ group: trade, items })
+  }
+
+  // 4) 미연결 실행계획
+  if (orphans.length) {
+    groups.push({
+      group: '미연결 실행계획',
+      isOrphan: true,
+      items: [
+        {
+          id: '__orphan__',
+          tradeProcessId: null,
+          name: '기준 공정에 연결되지 않은 세부계획',
+          trade: '미연결',
+          weightPct: null,
+          baselineStart: null,
+          baselineEnd: null,
+          milestoneDate: null,
+          milestoneFromAnnual: false,
+          isMilestone: false,
+          details: orphans.map((w) => ({
+            id: w.id,
+            name: w.name,
+            location: w.location || '',
+            plannedStart: workPlanPlannedStart(w),
+            plannedEnd: workPlanPlannedEnd(w),
+            start: w.start,
+            end: effectiveEnd(w),
+            status: workPlanStatus(w),
+            raw: w,
+          })),
+        },
+      ],
+    })
+  }
+
+  return groups
+}
+
+// 연간: 공종 → 공정 → 위치별 실행계획 (3단)
+const yearlyGroups = computed(() => buildGroups(annualPlans.value))
+// 월간: 공종 → 공정(마일스톤) → 세부계획(파란/빨간선) (3단)
+const monthlyGroups = computed(() => buildMonthlyGroups(monthlyPlans.value))
+
+// 공종 그룹 펼침 상태
+const groupOpen = ref({})
+
+// 월간: 공정별 펼침 상태 (공정 ID 기준)
+const monthlyProcessOpen = ref({})
+
+watch(
+  [yearlyGroups, monthlyGroups],
+  () => {
+    const all = [...yearlyGroups.value, ...monthlyGroups.value]
+    for (const g of all) {
+      if (groupOpen.value[g.group] === undefined) {
+        groupOpen.value[g.group] = true
+      }
+    }
+    // 월간 공정 펼침 상태 초기화 (기본: 펼쳐짐)
+    for (const g of monthlyGroups.value) {
+      for (const item of g.items) {
+        if (monthlyProcessOpen.value[item.id] === undefined) {
+          monthlyProcessOpen.value[item.id] = true
+        }
+      }
+    }
+  },
+  { immediate: true },
+)
+
+// 공정 한 줄의 고정 높이 (좌측 컨텐츠와 우측 차트 행이 정확히 일치하도록)
+// 좌측 컨텐츠 실측:
+//   - py-2 위아래 = 16px
+//   - 공정명 줄 = 20px
+//   - 기준기간 줄 = 14px
+//   - gap-0.5 = 2px × 2 = 4px
+//   - workPlans ul: mt-1 (4px) + 각 wp 14px + space-y-0.5 (2px)
+// 우측 차트:
+//   - 기준선 top:14, 실행선 top:34부터 20px 간격
+function processRowHeight(item) {
+  const wp = item.workPlans?.length || 0
+  // 헤더부(공정명+기준기간+padding) 약 60px + workPlans 영역
+  const wpArea = wp === 0 ? 18 : 4 + wp * 18 // mt-1 + 줄당 약 18px
+  const left = 60 + wpArea
+  // 우측 차트가 모든 실행선을 보여주려면 (workPlanTop(last) + 6) 이상 필요
+  const right = wp === 0 ? 48 : workPlanTop(wp - 1) + 14
+  return Math.max(left, right, 56)
+}
+
+// 월간: 공정 헤더 행 한 줄 높이 (공정명 + 마일스톤 표시)
+const MONTHLY_PROCESS_HEADER_H = 44
+// 월간: 세부계획 한 줄 높이 (파란선 + 빨간선 한 쌍 들어갈 공간)
+const MONTHLY_DETAIL_ROW_H = 32
+
+function monthlyProcessHeaderHeight() {
+  return MONTHLY_PROCESS_HEADER_H
+}
+function monthlyDetailRowHeight() {
+  return MONTHLY_DETAIL_ROW_H
+}
+
+// work_plan 실행선의 top 위치
+function workPlanTop(idx) {
+  return 34 + idx * 20
+}
+
+// 기준선 클릭 (수정 불가 안내)
+function onClickBaseline(item) {
+  selectedPlan.value = {
+    __baseline: true,
+    id: `base-${item.id}`,
+    name: item.name,
+    trade: item.trade,
+    start: item.baselineStart,
+    end: item.baselineEnd,
+    weightPct: item.weightPct,
+    location: '',
+  }
+}
+
+// 실행선 클릭 (기존 selectedPlan 동작)
+function onClickWorkPlan(wp) {
+  if (wp.isDefault) {
+    // 기본 실행 일정 = 기준 일정과 동일하므로 baseline 안내로 표시
+    selectedPlan.value = {
+      __baseline: true,
+      id: `default-${wp.id}`,
+      name: wp.name,
+      trade: '',
+      start: wp.start,
+      end: wp.end,
+      weightPct: null,
+      location: wp.location,
+    }
+    return
+  }
+  selectedPlan.value = wp.raw
 }
 </script>
 
@@ -1064,136 +1647,167 @@ function selectViewMode(mode) {
                 </p>
               </div>
               <span
+                v-if="!selectedPlan.__baseline"
                 class="shrink-0 rounded-lg px-2.5 py-1 text-xs font-bold"
                 :class="statusClass(workPlanStatus(selectedPlan))"
                 >{{ workPlanStatus(selectedPlan) }}</span
               >
+              <span
+                v-else
+                class="shrink-0 rounded-lg bg-blue-50 px-2.5 py-1 text-xs font-bold text-blue-700 ring-1 ring-blue-200"
+              >
+                기준 일정
+              </span>
             </div>
 
+            <!-- 기준 일정 (trade_process) 안내 배너 -->
             <div
-              v-if="selectedPlan.planType === '주간'"
-              class="mb-4 rounded-xl border border-forena-100 bg-white p-3.5"
+              v-if="selectedPlan.__baseline"
+              class="mb-4 flex items-start gap-2 rounded-xl border border-blue-200 bg-blue-50/60 p-3"
             >
-              <div class="mb-3 flex items-center gap-1.5">
-                <ClipboardList class="h-3.5 w-3.5 text-flare-600" />
-                <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
-                  >주간 계획서 정보</span
-                >
-              </div>
-              <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                <div class="rounded-lg bg-forena-50/60 px-3 py-2">
-                  <p class="text-[10px] font-bold text-forena-400">협력사</p>
-                  <p class="mt-1 text-sm font-semibold text-forena-900">
-                    {{ selectedPlan.partner || '-' }}
-                  </p>
-                </div>
-                <div class="rounded-lg bg-forena-50/60 px-3 py-2">
-                  <p class="text-[10px] font-bold text-forena-400">담당자</p>
-                  <p class="mt-1 text-sm font-semibold text-forena-900">
-                    {{ selectedPlan.manager || '-' }}
-                  </p>
-                </div>
-                <div class="rounded-lg bg-forena-50/60 px-3 py-2">
-                  <p class="text-[10px] font-bold text-forena-400">연락처</p>
-                  <p class="mt-1 text-sm font-semibold text-forena-900">
-                    {{ selectedPlan.contact || '-' }}
-                  </p>
-                </div>
-                <div class="rounded-lg bg-forena-50/60 px-3 py-2">
-                  <p class="text-[10px] font-bold text-forena-400">주 시작일</p>
-                  <p class="mt-1 text-sm font-semibold tabular-nums text-forena-900">
-                    {{ displayWeekStart(selectedPlan) }}
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <!-- ★ 연장 알림 박스 -->
-            <div
-              v-if="extOf(selectedPlan)"
-              class="mb-4 flex items-start gap-2.5 rounded-xl border border-emerald-200 bg-emerald-50/50 p-3.5"
-            >
-              <CalendarPlus class="h-4 w-4 shrink-0 text-emerald-600 mt-0.5" />
-              <div class="flex-1">
-                <p class="text-xs font-bold text-emerald-700">공정 분석을 통한 일정 연장</p>
-                <p class="mt-1 text-[11px] text-emerald-800">
-                  종료일 <span class="font-bold tabular-nums">{{ selectedPlan.end }}</span> →
-                  <span class="font-bold tabular-nums">{{ extOf(selectedPlan).extendedEnd }}</span>
-                  (+{{ extOf(selectedPlan).addedDays }}일)
-                </p>
-                <p
-                  v-if="extOf(selectedPlan).reason"
-                  class="mt-1 text-[11px] text-emerald-700/80 leading-relaxed"
-                >
-                  {{ extOf(selectedPlan).reason }}
-                </p>
-                <p class="mt-1 text-[10px] text-emerald-600">
-                  반영 {{ extOf(selectedPlan).decidedAt }}
+              <AlertTriangle class="mt-0.5 h-4 w-4 shrink-0 text-blue-600" />
+              <div class="text-[12px] leading-5 text-blue-800">
+                <p class="font-bold">전체 공정표 기준 일정입니다</p>
+                <p class="mt-0.5 text-blue-700">
+                  이 일정은 최초 공정표에서 생성된 기준 데이터로, 화면에서 직접 수정할 수 없습니다.
+                  실행 일정을 조정하려면 하위의 빨간 실행/진행선(연간/월간 작업계획)을 선택해
+                  주세요.
+                  <span v-if="selectedPlan.weightPct != null"
+                    >· 보할율 {{ selectedPlan.weightPct }}%</span
+                  >
                 </p>
               </div>
             </div>
 
-            <div class="grid gap-3 sm:grid-cols-3">
-              <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
-                <div class="flex items-center gap-1.5 mb-2">
-                  <MapPin class="h-3.5 w-3.5 text-flare-600" />
+            <!-- work_plan 전용 상세 (baseline일 땐 숨김) -->
+            <template v-if="!selectedPlan.__baseline">
+              <div
+                v-if="selectedPlan.planType === '주간'"
+                class="mb-4 rounded-xl border border-forena-100 bg-white p-3.5"
+              >
+                <div class="mb-3 flex items-center gap-1.5">
+                  <ClipboardList class="h-3.5 w-3.5 text-flare-600" />
                   <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
-                    >작업 위치</span
+                    >주간 계획서 정보</span
                   >
                 </div>
-                <p class="text-sm font-semibold text-forena-900">{{ selectedPlan.location }}</p>
-              </div>
-              <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
-                <div class="flex items-center gap-1.5 mb-2">
-                  <Users class="h-3.5 w-3.5 text-flare-600" />
-                  <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
-                    >필요 인원</span
-                  >
-                </div>
-                <ul v-if="selectedPlan.workers && selectedPlan.workers.length" class="space-y-1">
-                  <li
-                    v-for="(w, i) in selectedPlan.workers"
-                    :key="i"
-                    class="flex items-baseline justify-between text-sm"
-                  >
-                    <span class="font-semibold text-forena-900">{{ w.trade }}</span>
-                    <span class="tabular-nums text-forena-700">{{ w.count }}명</span>
-                  </li>
-                </ul>
-                <p v-else class="text-sm text-slate-400">해당 없음</p>
-                <div
-                  v-if="selectedPlan.requiredCount"
-                  class="mt-2 flex items-baseline justify-between border-t border-forena-100 pt-1.5"
-                >
-                  <span class="text-[10px] font-bold uppercase text-forena-400">합계</span>
-                  <span class="text-xs font-bold tabular-nums text-flare-700">
-                    {{ selectedPlan.requiredCount }}명
-                  </span>
+                <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                  <div class="rounded-lg bg-forena-50/60 px-3 py-2">
+                    <p class="text-[10px] font-bold text-forena-400">협력사</p>
+                    <p class="mt-1 text-sm font-semibold text-forena-900">
+                      {{ selectedPlan.partner || '-' }}
+                    </p>
+                  </div>
+                  <div class="rounded-lg bg-forena-50/60 px-3 py-2">
+                    <p class="text-[10px] font-bold text-forena-400">담당자</p>
+                    <p class="mt-1 text-sm font-semibold text-forena-900">
+                      {{ selectedPlan.manager || '-' }}
+                    </p>
+                  </div>
+                  <div class="rounded-lg bg-forena-50/60 px-3 py-2">
+                    <p class="text-[10px] font-bold text-forena-400">연락처</p>
+                    <p class="mt-1 text-sm font-semibold text-forena-900">
+                      {{ selectedPlan.contact || '-' }}
+                    </p>
+                  </div>
+                  <div class="rounded-lg bg-forena-50/60 px-3 py-2">
+                    <p class="text-[10px] font-bold text-forena-400">주 시작일</p>
+                    <p class="mt-1 text-sm font-semibold tabular-nums text-forena-900">
+                      {{ displayWeekStart(selectedPlan) }}
+                    </p>
+                  </div>
                 </div>
               </div>
-              <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
-                <div class="flex items-center gap-1.5 mb-2">
-                  <Wrench class="h-3.5 w-3.5 text-flare-600" />
-                  <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
-                    >필요 장비</span
+
+              <!-- ★ 연장 알림 박스 -->
+              <div
+                v-if="extOf(selectedPlan)"
+                class="mb-4 flex items-start gap-2.5 rounded-xl border border-emerald-200 bg-emerald-50/50 p-3.5"
+              >
+                <CalendarPlus class="h-4 w-4 shrink-0 text-emerald-600 mt-0.5" />
+                <div class="flex-1">
+                  <p class="text-xs font-bold text-emerald-700">공정 분석을 통한 일정 연장</p>
+                  <p class="mt-1 text-[11px] text-emerald-800">
+                    종료일 <span class="font-bold tabular-nums">{{ selectedPlan.end }}</span> →
+                    <span class="font-bold tabular-nums">{{
+                      extOf(selectedPlan).extendedEnd
+                    }}</span>
+                    (+{{ extOf(selectedPlan).addedDays }}일)
+                  </p>
+                  <p
+                    v-if="extOf(selectedPlan).reason"
+                    class="mt-1 text-[11px] text-emerald-700/80 leading-relaxed"
                   >
+                    {{ extOf(selectedPlan).reason }}
+                  </p>
+                  <p class="mt-1 text-[10px] text-emerald-600">
+                    반영 {{ extOf(selectedPlan).decidedAt }}
+                  </p>
                 </div>
-                <ul
-                  v-if="selectedPlan.equipment && selectedPlan.equipment.length"
-                  class="space-y-1"
-                >
-                  <li
-                    v-for="(eq, i) in selectedPlan.equipment"
-                    :key="i"
-                    class="flex items-baseline justify-between text-sm"
-                  >
-                    <span class="font-semibold text-forena-900">{{ eq.type }}</span>
-                    <span class="tabular-nums text-forena-700">{{ eq.count }}대</span>
-                  </li>
-                </ul>
-                <p v-else class="text-sm text-slate-400">해당 없음</p>
               </div>
-            </div>
+
+              <div class="grid gap-3 sm:grid-cols-3">
+                <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
+                  <div class="flex items-center gap-1.5 mb-2">
+                    <MapPin class="h-3.5 w-3.5 text-flare-600" />
+                    <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
+                      >작업 위치</span
+                    >
+                  </div>
+                  <p class="text-sm font-semibold text-forena-900">{{ selectedPlan.location }}</p>
+                </div>
+                <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
+                  <div class="flex items-center gap-1.5 mb-2">
+                    <Users class="h-3.5 w-3.5 text-flare-600" />
+                    <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
+                      >필요 인원</span
+                    >
+                  </div>
+                  <ul v-if="selectedPlan.workers && selectedPlan.workers.length" class="space-y-1">
+                    <li
+                      v-for="(w, i) in selectedPlan.workers"
+                      :key="i"
+                      class="flex items-baseline justify-between text-sm"
+                    >
+                      <span class="font-semibold text-forena-900">{{ w.trade }}</span>
+                      <span class="tabular-nums text-forena-700">{{ w.count }}명</span>
+                    </li>
+                  </ul>
+                  <p v-else class="text-sm text-slate-400">해당 없음</p>
+                  <div
+                    v-if="selectedPlan.requiredCount"
+                    class="mt-2 flex items-baseline justify-between border-t border-forena-100 pt-1.5"
+                  >
+                    <span class="text-[10px] font-bold uppercase text-forena-400">합계</span>
+                    <span class="text-xs font-bold tabular-nums text-flare-700">
+                      {{ selectedPlan.requiredCount }}명
+                    </span>
+                  </div>
+                </div>
+                <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
+                  <div class="flex items-center gap-1.5 mb-2">
+                    <Wrench class="h-3.5 w-3.5 text-flare-600" />
+                    <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
+                      >필요 장비</span
+                    >
+                  </div>
+                  <ul
+                    v-if="selectedPlan.equipment && selectedPlan.equipment.length"
+                    class="space-y-1"
+                  >
+                    <li
+                      v-for="(eq, i) in selectedPlan.equipment"
+                      :key="i"
+                      class="flex items-baseline justify-between text-sm"
+                    >
+                      <span class="font-semibold text-forena-900">{{ eq.type }}</span>
+                      <span class="tabular-nums text-forena-700">{{ eq.count }}대</span>
+                    </li>
+                  </ul>
+                  <p v-else class="text-sm text-slate-400">해당 없음</p>
+                </div>
+              </div>
+            </template>
           </div>
         </template>
 
@@ -1215,10 +1829,27 @@ function selectViewMode(mode) {
               <!-- 간트차트 범례 -->
               <div v-if="viewMode !== 'weekly'" class="flex items-center gap-3 text-[10px]">
                 <span class="flex items-center gap-1.5 text-forena-500">
-                  <span class="h-[3px] w-5 rounded-full bg-violet-600"></span>계획서 기준
+                  <span class="h-[3px] w-5 rounded-full bg-blue-600"></span>전체 공정표 기준
                 </span>
                 <span class="flex items-center gap-1.5 text-forena-500">
-                  <span class="h-[3px] w-5 rounded-full bg-green-700"></span>실제/예상 진행
+                  <span class="relative h-[3px] w-5 rounded-full bg-red-200">
+                    <span class="absolute inset-y-0 left-0 w-1/2 rounded-full bg-red-500"></span>
+                  </span>
+                  {{ viewMode === 'yearly' ? '연간' : '월간' }} 실행/진행
+                </span>
+                <span class="flex items-center gap-1.5 text-forena-500">
+                  <svg class="h-3 w-3" viewBox="0 0 12 12">
+                    <path
+                      d="M6 1 L11 6 L6 11 L1 6 Z"
+                      fill="#f59e0b"
+                      stroke="#b45309"
+                      stroke-width="1"
+                    />
+                  </svg>
+                  마일스톤
+                </span>
+                <span class="flex items-center gap-1.5 text-forena-500">
+                  <span class="h-3 w-px bg-flare-500"></span>오늘
                 </span>
               </div>
 
@@ -1382,47 +2013,83 @@ function selectViewMode(mode) {
           </div>
 
           <!-- ========== 연간 (간트차트) ========== -->
+          <!-- 구조: 공종 그룹 → 공정(파란 기준선) → 위치별 실행계획(빨간 실행/진행선들) -->
           <div v-else-if="viewMode === 'yearly'" class="min-h-0 flex-1 overflow-auto bg-white">
             <div
-              v-if="!yearlyPlans.length"
+              v-if="!yearlyGroups.length"
               class="flex items-center justify-center py-16 text-sm text-slate-400"
             >
-              {{ yearMeta.year }}년에 표시할 작업이 없습니다.
+              {{ yearMeta.year }}년에 표시할 기준 공정이 없습니다.
             </div>
 
             <div v-else class="flex min-w-max">
+              <!-- 좌측: 공종 그룹 → 공정 → 실행계획 목록 -->
               <div
                 class="sticky left-0 z-10 shrink-0 border-r border-forena-200 bg-white"
                 :style="{ width: NAME_COL_W + 'px' }"
               >
                 <div class="flex h-10 items-center border-b border-forena-200 bg-white px-4">
-                  <span class="text-[11px] font-bold text-forena-500">공정명 / 공종</span>
+                  <span class="text-[11px] font-bold text-forena-500">공종 / 공정 / 실행위치</span>
                 </div>
-                <div
-                  v-for="p in yearlyPlans"
-                  :key="p.id"
-                  class="flex h-[68px] cursor-pointer flex-col justify-center gap-0.5 border-b border-forena-100 px-4 transition hover:bg-forena-50/60"
-                  :class="selectedPlan?.id === p.id ? 'bg-flare-50/60' : ''"
-                  @click="selectedPlan = p"
-                >
-                  <div class="flex items-center gap-1.5">
-                    <p class="truncate text-sm font-bold text-forena-900">{{ p.name }}</p>
+
+                <template v-for="grp in yearlyGroups" :key="`y-grp-${grp.group}`">
+                  <!-- 공종 그룹 헤더 (접기/펼치기) -->
+                  <div
+                    class="flex h-9 cursor-pointer items-center justify-between border-b border-forena-200 bg-gradient-to-r from-forena-100 to-forena-50 px-3 text-[11px] font-bold text-forena-800 transition hover:from-flare-50 hover:to-flare-50/30"
+                    @click="groupOpen[grp.group] = !groupOpen[grp.group]"
+                  >
+                    <div class="flex items-center gap-1.5">
+                      <ChevronDown
+                        v-if="groupOpen[grp.group]"
+                        class="h-3.5 w-3.5 text-forena-600"
+                      />
+                      <ChevronRight v-else class="h-3.5 w-3.5 text-forena-600" />
+                      <span>{{ grp.group }}</span>
+                    </div>
                     <span
-                      v-if="extOf(p)"
-                      class="inline-flex items-center gap-0.5 rounded bg-emerald-50 px-1 py-0.5 text-[9px] font-bold text-emerald-700"
+                      class="rounded bg-white/70 px-1.5 py-0.5 text-[9px] tabular-nums text-forena-500"
+                      >{{ grp.items.length }}</span
                     >
-                      <CalendarPlus class="h-2.5 w-2.5" />+{{ extOf(p).addedDays }}일
-                    </span>
                   </div>
-                  <p class="truncate text-[11px] text-forena-500">
-                    {{ p.trade }}{{ p.location ? ` / ${p.location}` : '' }}
-                  </p>
-                  <p v-if="p.sourceFile" class="truncate text-[10px] text-slate-400">
-                    출처 문서: {{ p.sourceFile }}
-                  </p>
-                </div>
+
+                  <template v-if="groupOpen[grp.group]">
+                    <div
+                      v-for="item in grp.items"
+                      :key="`y-item-${item.id}`"
+                      class="flex cursor-pointer flex-col justify-start gap-0.5 overflow-hidden border-b border-forena-100 px-4 py-2 transition hover:bg-forena-50/60"
+                      :style="{ height: processRowHeight(item) + 'px' }"
+                    >
+                      <!-- 공정명 + 보할 -->
+                      <div class="flex items-center gap-1.5" @click="onClickBaseline(item)">
+                        <p class="truncate text-sm font-bold text-forena-900">{{ item.name }}</p>
+                        <span
+                          v-if="item.weightPct != null"
+                          class="rounded bg-blue-50 px-1 py-0.5 text-[9px] font-bold text-blue-700"
+                        >
+                          보할 {{ item.weightPct }}%
+                        </span>
+                      </div>
+                      <p class="truncate text-[10px] text-slate-400">
+                        기준 {{ item.baselineStart || '-' }} ~ {{ item.baselineEnd || '-' }}
+                      </p>
+                      <!-- 하위 work_plan 위치 목록 -->
+                      <ul v-if="item.workPlans.length" class="mt-1 space-y-0.5">
+                        <li
+                          v-for="wp in item.workPlans"
+                          :key="`y-wp-${wp.id}`"
+                          class="truncate text-[10px] text-red-600 hover:text-red-700"
+                          @click.stop="onClickWorkPlan(wp)"
+                        >
+                          └ {{ wp.location || wp.name }} 실행
+                        </li>
+                      </ul>
+                      <p v-else class="text-[10px] italic text-slate-300">실행 일정 없음</p>
+                    </div>
+                  </template>
+                </template>
               </div>
 
+              <!-- 우측: 차트 (공종 헤더 라인 + 공정 행마다 파란선 + 빨간 실행/진행선들) -->
               <div class="relative" :style="{ width: yearChartWidth + 'px' }">
                 <div class="sticky top-0 z-[5] flex h-10 border-b border-forena-200 bg-white">
                   <div
@@ -1437,118 +2104,220 @@ function selectViewMode(mode) {
                 </div>
 
                 <div class="relative">
-                  <div
-                    v-for="p in yearlyPlans"
-                    :key="p.id"
-                    class="relative flex h-[68px] border-b border-forena-100"
-                    :class="selectedPlan?.id === p.id ? 'bg-flare-50/40' : ''"
-                  >
+                  <template v-for="grp in yearlyGroups" :key="`y-grow-${grp.group}`">
+                    <!-- 공종 그룹 헤더 (오른쪽 빈 영역 - 좌측과 높이 매칭) -->
                     <div
-                      v-for="m in yearMeta.months"
-                      :key="m.month"
-                      class="border-r border-forena-50"
-                      :style="{ width: GANTT_MONTH_W + 'px' }"
+                      class="h-9 border-b border-forena-200 bg-gradient-to-r from-forena-100 to-forena-50"
                     ></div>
 
-                    <div
-                      v-if="yearBarStyle(p.start, p.end)"
-                      class="group absolute z-[2] flex cursor-pointer items-center"
-                      :style="{ ...yearBarStyle(p.start, p.end), top: '20px', height: '4px' }"
-                      :title="`계획서 기준: ${p.start} ~ ${p.end}`"
-                      @click="selectedPlan = p"
-                    >
-                      <span
-                        class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-violet-600 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-violet-600 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="h-1 w-full rounded-full bg-violet-600 transition group-hover:h-1.5"
-                      ></span>
-                    </div>
+                    <template v-if="groupOpen[grp.group]">
+                      <div
+                        v-for="item in grp.items"
+                        :key="`y-row-${item.id}`"
+                        class="relative flex border-b border-forena-100"
+                        :style="{ height: processRowHeight(item) + 'px' }"
+                      >
+                        <!-- 월 셀 그리드 -->
+                        <div
+                          v-for="m in yearMeta.months"
+                          :key="m.month"
+                          class="border-r border-forena-50"
+                          :style="{ width: GANTT_MONTH_W + 'px' }"
+                        ></div>
 
-                    <div
-                      v-if="yearBarStyle(actualLineRange(p).start, actualLineRange(p).end)"
-                      class="absolute z-[1] flex cursor-pointer items-center"
-                      :style="{
-                        ...yearBarStyle(actualLineRange(p).start, actualLineRange(p).end),
-                        top: '40px',
-                        height: '4px',
-                      }"
-                      :title="`실제/예상 진행: ${actualLineRange(p).start} ~ ${actualLineRange(p).end}`"
-                      @click="selectedPlan = p"
-                    >
-                      <span class="h-1 w-full rounded-full bg-green-300"></span>
-                    </div>
-                    <div
-                      v-if="
-                        progressFillEnd(p) &&
-                        yearBarStyle(actualLineRange(p).start, progressFillEnd(p))
-                      "
-                      class="absolute z-[2] flex cursor-pointer items-center"
-                      :style="{
-                        ...yearBarStyle(actualLineRange(p).start, progressFillEnd(p)),
-                        top: '40px',
-                        height: '4px',
-                      }"
-                      @click="selectedPlan = p"
-                    >
-                      <span
-                        class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-green-700 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-green-700 ring-2 ring-white"
-                      ></span>
-                      <span class="h-1 w-full rounded-full bg-green-700"></span>
-                    </div>
-                  </div>
+                        <!-- 마일스톤 (있을 경우) -->
+                        <!-- baseline 시작점에 다이아몬드 표시 -->
+
+                        <!-- 파란색: 기준 일정 (trade_process) -->
+                        <div
+                          v-if="
+                            item.baselineStart &&
+                            item.baselineEnd &&
+                            yearBarStyle(item.baselineStart, item.baselineEnd)
+                          "
+                          class="group absolute z-[2] flex cursor-pointer items-center"
+                          :style="{
+                            ...yearBarStyle(item.baselineStart, item.baselineEnd),
+                            top: '14px',
+                            height: '4px',
+                          }"
+                          :title="`기준 일정 (수정 불가): ${item.baselineStart} ~ ${item.baselineEnd}`"
+                          @click="onClickBaseline(item)"
+                        >
+                          <span
+                            class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-blue-600 ring-2 ring-white"
+                          ></span>
+                          <span
+                            class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-blue-600 ring-2 ring-white"
+                          ></span>
+                          <span class="h-1 w-full rounded-full bg-blue-600"></span>
+                        </div>
+
+                        <!-- 빨간색: 위치별 실행 일정 + 진행률 (work_plan) - 여러 줄 -->
+                        <div
+                          v-for="(wp, wi) in item.workPlans"
+                          :key="`y-wpbar-${wp.id}`"
+                          class="group absolute z-[2] cursor-pointer"
+                          :style="{
+                            ...(yearBarStyle(wp.start, wp.end) || { display: 'none' }),
+                            top: workPlanTop(wi) + 'px',
+                            height: '4px',
+                          }"
+                          :title="`${wp.name}${wp.location ? ' · ' + wp.location : ''}\n${wp.start} ~ ${wp.end}`"
+                          @click.stop="onClickWorkPlan(wp)"
+                        >
+                          <!-- 실행 일정 시작점 -->
+                          <span
+                            class="absolute -left-[3px] top-1/2 z-[3] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                          ></span>
+
+                          <!-- 실행 일정 종료점 -->
+                          <span
+                            class="absolute -right-[3px] top-1/2 z-[3] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                          ></span>
+
+                          <!-- 실행 일정 전체 기간: 연한 빨간색 -->
+                          <span class="absolute inset-0 z-0 rounded-full bg-red-200"></span>
+
+                          <!-- 진행률 게이지: 진한 빨간색 -->
+                          <span
+                            class="absolute inset-y-0 left-0 z-[1] rounded-full bg-red-500 transition group-hover:h-1.5"
+                            :style="progressBarStyle(wp, yearBarStyle)"
+                          ></span>
+
+                          <!-- 진행률 위치 점 -->
+                          <span
+                            class="absolute top-1/2 z-[4] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                            :style="progressDotStyle(wp, yearBarStyle)"
+                          ></span>
+                        </div>
+                      </div>
+                    </template>
+                  </template>
                 </div>
               </div>
             </div>
           </div>
 
           <!-- ========== 월간 (라인형 간트차트) ========== -->
+          <!-- 구조: 공종 그룹 → 공정 행(접기/펼치기, 마일스톤) → 세부계획 행들(파란 월간기준선 + 빨간 실행선) -->
           <div v-else class="min-h-0 flex-1 overflow-auto bg-white">
             <div
-              v-if="!ganttPlans.length"
+              v-if="!monthlyGroups.length"
               class="flex items-center justify-center py-16 text-sm text-slate-400"
             >
-              {{ monthMeta.year }}년 {{ monthMeta.month }}월에 표시할 작업이 없습니다.
+              {{ monthMeta.year }}년 {{ monthMeta.month }}월에 표시할 기준 공정이 없습니다.
             </div>
 
             <div v-else class="flex min-w-max">
-              <!-- 좌측: 작업명 -->
+              <!-- 좌측: 공종 → 공정 → 세부계획 목록 -->
               <div
                 class="sticky left-0 z-10 shrink-0 border-r border-forena-200 bg-white"
                 :style="{ width: NAME_COL_W + 'px' }"
               >
                 <div class="flex h-10 items-center border-b border-forena-200 bg-white px-4">
-                  <span class="text-[11px] font-bold text-forena-500">공정명 / 공종</span>
+                  <span class="text-[11px] font-bold text-forena-500">공종 / 공정 / 세부계획</span>
                 </div>
-                <div
-                  v-for="p in ganttPlans"
-                  :key="p.id"
-                  class="flex h-[68px] cursor-pointer flex-col justify-center gap-0.5 border-b border-forena-100 px-4 transition hover:bg-forena-50/60"
-                  :class="selectedPlan?.id === p.id ? 'bg-flare-50/60' : ''"
-                  @click="selectedPlan = p"
-                >
-                  <div class="flex items-center gap-1.5">
-                    <p class="truncate text-sm font-bold text-forena-900">{{ p.name }}</p>
+
+                <template v-for="grp in monthlyGroups" :key="`m-grp-${grp.group}`">
+                  <!-- 공종 그룹 헤더 -->
+                  <div
+                    class="flex h-9 cursor-pointer items-center justify-between border-b border-forena-200 bg-gradient-to-r from-forena-100 to-forena-50 px-3 text-[11px] font-bold text-forena-800 transition hover:from-flare-50 hover:to-flare-50/30"
+                    @click="groupOpen[grp.group] = !groupOpen[grp.group]"
+                  >
+                    <div class="flex items-center gap-1.5">
+                      <ChevronDown
+                        v-if="groupOpen[grp.group]"
+                        class="h-3.5 w-3.5 text-forena-600"
+                      />
+                      <ChevronRight v-else class="h-3.5 w-3.5 text-forena-600" />
+                      <span>{{ grp.group }}</span>
+                    </div>
                     <span
-                      v-if="extOf(p)"
-                      class="inline-flex items-center gap-0.5 rounded bg-emerald-50 px-1 py-0.5 text-[9px] font-bold text-emerald-700"
+                      class="rounded bg-white/70 px-1.5 py-0.5 text-[9px] tabular-nums text-forena-500"
+                      >{{ grp.items.length }}</span
                     >
-                      <CalendarPlus class="h-2.5 w-2.5" />+{{ extOf(p).addedDays }}일
-                    </span>
                   </div>
-                  <p class="truncate text-[11px] text-forena-500">
-                    {{ p.trade }}{{ p.location ? ` / ${p.location}` : '' }}
-                  </p>
-                  <p v-if="p.sourceFile" class="truncate text-[10px] text-slate-400">
-                    출처 문서: {{ p.sourceFile }}
-                  </p>
-                </div>
+
+                  <template v-if="groupOpen[grp.group]">
+                    <template v-for="item in grp.items" :key="`m-item-${item.id}`">
+                      <!-- 공정 행 (접기/펼치기) -->
+                      <div
+                        class="flex cursor-pointer items-center gap-1.5 border-b border-forena-100 bg-slate-50/40 pl-4 pr-3 transition hover:bg-forena-50/60"
+                        :style="{ height: monthlyProcessHeaderHeight() + 'px' }"
+                        @click="monthlyProcessOpen[item.id] = !monthlyProcessOpen[item.id]"
+                      >
+                        <ChevronDown
+                          v-if="monthlyProcessOpen[item.id]"
+                          class="h-3.5 w-3.5 shrink-0 text-slate-500"
+                        />
+                        <ChevronRight v-else class="h-3.5 w-3.5 shrink-0 text-slate-500" />
+                        <div class="flex min-w-0 flex-1 flex-col">
+                          <div class="flex items-center gap-1.5">
+                            <p
+                              class="truncate text-sm font-bold text-forena-900"
+                              @click.stop="onClickBaseline(item)"
+                            >
+                              {{ item.name }}
+                            </p>
+                            <span
+                              v-if="item.weightPct != null"
+                              class="rounded bg-blue-50 px-1 py-0.5 text-[9px] font-bold text-blue-700"
+                            >
+                              보할 {{ item.weightPct }}%
+                            </span>
+                          </div>
+                          <p class="truncate text-[10px] text-slate-400">
+                            <span
+                              v-if="item.milestoneDate"
+                              class="inline-flex items-center gap-1"
+                              :title="
+                                item.milestoneFromAnnual
+                                  ? '연간 실행계획 종료일을 마일스톤으로 사용'
+                                  : '기준 공정 종료일'
+                              "
+                            >
+                              <span class="inline-block h-1.5 w-1.5 rotate-45 bg-rose-500"></span>
+                              마일스톤 {{ item.milestoneDate }}
+                            </span>
+                            <span v-else class="italic text-slate-300">마일스톤 없음</span>
+                          </p>
+                        </div>
+                        <span
+                          class="rounded bg-white/70 px-1.5 py-0.5 text-[9px] tabular-nums text-slate-500"
+                          >{{ (item.details && item.details.length) || 0 }}</span
+                        >
+                      </div>
+
+                      <!-- 세부계획 행들 (공정이 펼쳐져 있을 때만) -->
+                      <template v-if="monthlyProcessOpen[item.id]">
+                        <div
+                          v-for="d in item.details"
+                          :key="`m-detail-${d.id}`"
+                          class="flex cursor-pointer items-center gap-1.5 border-b border-forena-50 pl-10 pr-3 transition hover:bg-rose-50/40"
+                          :style="{ height: monthlyDetailRowHeight() + 'px' }"
+                          @click.stop="onClickWorkPlan(d)"
+                        >
+                          <span class="shrink-0 text-[10px] text-slate-300">└</span>
+                          <p class="truncate text-[11px] text-slate-700">
+                            {{ d.name
+                            }}<span v-if="d.location" class="text-slate-400">
+                              · {{ d.location }}</span
+                            >
+                          </p>
+                        </div>
+                        <!-- 세부계획이 하나도 없을 때 안내 행 -->
+                        <div
+                          v-if="!item.details || !item.details.length"
+                          class="flex items-center border-b border-forena-50 pl-10 pr-3 text-[10px] italic text-slate-300"
+                          :style="{ height: monthlyDetailRowHeight() + 'px' }"
+                        >
+                          세부계획 없음 (월간 계획서를 업로드하세요)
+                        </div>
+                      </template>
+                    </template>
+                  </template>
+                </template>
               </div>
 
               <!-- 우측: 차트 -->
@@ -1574,78 +2343,132 @@ function selectViewMode(mode) {
                     :style="todayLineStyle"
                   ></div>
 
-                  <!-- 작업 행들 -->
-                  <div
-                    v-for="p in ganttPlans"
-                    :key="p.id"
-                    class="relative flex h-[68px] border-b border-forena-100"
-                    :class="selectedPlan?.id === p.id ? 'bg-flare-50/40' : ''"
-                  >
-                    <!-- 셀 그리드 -->
+                  <template v-for="grp in monthlyGroups" :key="`m-grow-${grp.group}`">
+                    <!-- 공종 그룹 헤더 (오른쪽 빈 영역) -->
                     <div
-                      v-for="d in monthMeta.days"
-                      :key="d.date"
-                      class="border-r border-forena-50"
-                      :style="{ width: GANTT_DAY_W + 'px' }"
-                      :class="monthlyDayCellClass(d)"
+                      class="h-9 border-b border-forena-200 bg-gradient-to-r from-forena-100 to-forena-50"
                     ></div>
 
-                    <!-- 계획 라인 (월간 작업계획서 기준) -->
-                    <div
-                      v-if="barStyle(p.start, p.end)"
-                      class="group absolute z-[2] flex cursor-pointer items-center"
-                      :style="{ ...barStyle(p.start, p.end), top: '20px', height: '4px' }"
-                      :title="`계획서 기준: ${p.start} ~ ${p.end}`"
-                      @click="selectedPlan = p"
-                    >
-                      <span
-                        class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-violet-600 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-violet-600 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="h-1 w-full rounded-full bg-violet-600 transition group-hover:h-1.5"
-                      ></span>
-                    </div>
+                    <template v-if="groupOpen[grp.group]">
+                      <template v-for="item in grp.items" :key="`m-row-${item.id}`">
+                        <!-- 공정 행: 마일스톤 마커 표시 -->
+                        <div
+                          class="relative flex border-b border-forena-100 bg-slate-50/40"
+                          :style="{ height: monthlyProcessHeaderHeight() + 'px' }"
+                        >
+                          <div
+                            v-for="d in monthMeta.days"
+                            :key="d.date"
+                            class="border-r border-forena-50"
+                            :style="{ width: GANTT_DAY_W + 'px' }"
+                            :class="monthlyDayCellClass(d)"
+                          ></div>
 
-                    <!-- 실제/예상 진행 라인: 연장 시 빨간 예상선이 연장 종료일까지 이어짐 -->
-                    <div
-                      v-if="barStyle(actualLineRange(p).start, actualLineRange(p).end)"
-                      class="absolute z-[1] flex cursor-pointer items-center"
-                      :style="{
-                        ...barStyle(actualLineRange(p).start, actualLineRange(p).end),
-                        top: '40px',
-                        height: '4px',
-                      }"
-                      :title="`실제/예상 진행: ${actualLineRange(p).start} ~ ${actualLineRange(p).end}`"
-                      @click="selectedPlan = p"
-                    >
-                      <span class="h-1 w-full rounded-full bg-green-300"></span>
-                    </div>
-                    <div
-                      v-if="
-                        progressFillEnd(p) && barStyle(actualLineRange(p).start, progressFillEnd(p))
-                      "
-                      class="group absolute z-[2] flex cursor-pointer items-center"
-                      :style="{
-                        ...barStyle(actualLineRange(p).start, progressFillEnd(p)),
-                        top: '40px',
-                        height: '4px',
-                      }"
-                      @click="selectedPlan = p"
-                    >
-                      <span
-                        class="absolute -left-[3px] h-2.5 w-2.5 rounded-full bg-green-700 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="absolute -right-[3px] h-2.5 w-2.5 rounded-full bg-green-700 ring-2 ring-white"
-                      ></span>
-                      <span
-                        class="h-1 w-full rounded-full bg-green-700 transition group-hover:h-1.5"
-                      ></span>
-                    </div>
-                  </div>
+                          <!-- 마일스톤 마커 (마름모) -->
+                          <div
+                            v-if="item.milestoneDate && monthCellCenterStyle(item.milestoneDate)"
+                            class="absolute z-[2] flex cursor-pointer items-center justify-center"
+                            :style="{
+                              ...monthCellCenterStyle(item.milestoneDate),
+                              top: '50%',
+                              width: '14px',
+                              height: '14px',
+                              transform: 'translate(-7px, -50%)',
+                            }"
+                            :title="`마일스톤: ${item.milestoneDate}`"
+                            @click.stop="onClickBaseline(item)"
+                          >
+                            <span
+                              class="block h-2.5 w-2.5 rotate-45 bg-rose-500 ring-2 ring-white"
+                            ></span>
+                          </div>
+                        </div>
+
+                        <!-- 세부계획 행들 -->
+                        <template v-if="monthlyProcessOpen[item.id]">
+                          <div
+                            v-for="d in item.details"
+                            :key="`m-detail-row-${d.id}`"
+                            class="relative flex border-b border-forena-50"
+                            :style="{ height: monthlyDetailRowHeight() + 'px' }"
+                          >
+                            <div
+                              v-for="dd in monthMeta.days"
+                              :key="dd.date"
+                              class="border-r border-forena-50"
+                              :style="{ width: GANTT_DAY_W + 'px' }"
+                              :class="monthlyDayCellClass(dd)"
+                            ></div>
+
+                            <!-- 파란선: 월간계획서 기준 (plannedStart/plannedEnd) -->
+                            <div
+                              v-if="
+                                d.plannedStart &&
+                                d.plannedEnd &&
+                                barStyle(d.plannedStart, d.plannedEnd)
+                              "
+                              class="group absolute z-[2] flex cursor-pointer items-center"
+                              :style="{
+                                ...barStyle(d.plannedStart, d.plannedEnd),
+                                top: '8px',
+                                height: '4px',
+                              }"
+                              :title="`월간 기준: ${d.plannedStart} ~ ${d.plannedEnd}`"
+                              @click.stop="onClickWorkPlan(d)"
+                            >
+                              <span
+                                class="absolute -left-[3px] h-2 w-2 rounded-full bg-blue-600 ring-2 ring-white"
+                              ></span>
+                              <span
+                                class="absolute -right-[3px] h-2 w-2 rounded-full bg-blue-600 ring-2 ring-white"
+                              ></span>
+                              <span class="h-1 w-full rounded-full bg-blue-600"></span>
+                            </div>
+
+                            <!-- 빨간선: 실행 일정 + 진행률 -->
+                            <div
+                              v-if="barStyle(d.start, d.end)"
+                              class="group absolute z-[2] cursor-pointer"
+                              :style="{
+                                ...barStyle(d.start, d.end),
+                                top: '20px',
+                                height: '4px',
+                              }"
+                              :title="`${d.name}${d.location ? ' · ' + d.location : ''}\n실행: ${d.start} ~ ${d.end}`"
+                              @click.stop="onClickWorkPlan(d)"
+                            >
+                              <span
+                                class="absolute -left-[3px] top-1/2 z-[2] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                              ></span>
+                              <span
+                                class="absolute top-1/2 z-[2] h-2 w-2 -translate-y-1/2 rounded-full bg-red-500 ring-2 ring-white"
+                                :style="progressDotStyle(d, barStyle)"
+                              ></span>
+                              <span class="absolute inset-0 z-0 rounded-full bg-red-200"></span>
+                              <span
+                                class="absolute inset-y-0 left-0 z-[1] rounded-full bg-red-500 transition group-hover:h-1.5"
+                                :style="progressBarStyle(d, barStyle)"
+                              ></span>
+                            </div>
+                          </div>
+                          <!-- 세부계획이 없을 때 빈 행 (좌측과 높이 매칭) -->
+                          <div
+                            v-if="!item.details || !item.details.length"
+                            class="relative flex border-b border-forena-50"
+                            :style="{ height: monthlyDetailRowHeight() + 'px' }"
+                          >
+                            <div
+                              v-for="dd in monthMeta.days"
+                              :key="dd.date"
+                              class="border-r border-forena-50"
+                              :style="{ width: GANTT_DAY_W + 'px' }"
+                              :class="monthlyDayCellClass(dd)"
+                            ></div>
+                          </div>
+                        </template>
+                      </template>
+                    </template>
+                  </template>
                 </div>
               </div>
             </div>
@@ -1909,6 +2732,36 @@ function selectViewMode(mode) {
             </button>
           </div>
 
+          <!-- 월간 계획 선택 -->
+          <div class="shrink-0 border-b border-forena-100 bg-white px-6 py-4">
+            <label class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500">
+              월간 계획 선택 <span class="text-rose-500">*</span>
+            </label>
+
+            <select
+              v-model="weeklyForm.monthlyPlanId"
+              @change="onSelectMonthlyPlan"
+              class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-2 text-xs outline-none focus:border-flare-400"
+            >
+              <option :value="null">월간 세부계획을 선택하세요</option>
+              <option v-for="opt in monthlyPlanOptions" :key="opt.id" :value="opt.id">
+                {{ opt.label }}
+              </option>
+            </select>
+
+            <div
+              v-if="weeklyForm.monthlyPlanId"
+              class="mt-3 rounded-lg border border-flare-100 bg-flare-50/50 px-3 py-2 text-xs text-forena-700"
+            >
+              <p class="font-bold text-forena-900">
+                {{ weeklyForm.monthlyPlanName }}
+              </p>
+              <p class="mt-1">
+                위치 {{ weeklyForm.monthlyLocation || '-' }} · 기간 {{ weeklyForm.monthlyStart }} ~
+                {{ weeklyForm.monthlyEnd }}
+              </p>
+            </div>
+          </div>
           <!-- 협력사 정보 -->
           <div
             class="grid shrink-0 grid-cols-1 gap-3 border-b border-forena-100 bg-forena-50/40 px-6 py-4 sm:grid-cols-4"
@@ -2005,17 +2858,17 @@ function selectViewMode(mode) {
                   </div>
                   <div class="lg:col-span-2">
                     <label class="mb-1 block text-[10px] font-bold text-forena-500"
-                      >공정명 <span class="text-rose-500">*</span></label
+                      >일일 작업 내용 <span class="text-rose-500">*</span></label
                     >
                     <input
                       v-model="item.processName"
-                      placeholder="예: B2층 전기 배관 설치"
+                      placeholder="예: 타설 전 거푸집 및 철근 상태 점검"
                       class="w-full rounded-md border border-forena-200 px-2 py-1.5 text-xs outline-none focus:border-flare-400"
                     />
                   </div>
                   <div class="lg:col-span-2">
                     <label class="mb-1 block text-[10px] font-bold text-forena-500"
-                      >작업구역 <span class="text-rose-500">*</span></label
+                      >세부 작업 위치 <span class="text-rose-500">*</span></label
                     >
                     <input
                       v-model="item.zone"


### PR DESCRIPTION
## :hammer_and_wrench: 작업 내용
- 공사일보 페이지 구현
- 공사일보 API 연동
- 명일 작업 스케줄 기반 공사일보 작성 기능 추가
- 투입 인원 및 투입 장비 연동 기능 추가

## :clipboard: 상세 내용
- 공사일보 목록 조회 기능 연동
- 작업일 기준 공사일보 조회 기능 구현
- 공사일보 작성 화면 구성
- 명일 작업 예정 데이터를 기반으로 공사일보 기본 정보 자동 생성
- 작업지시서/주간 계획과 연동하여 작업 스케줄 정보 불러오기
- 실제 투입 인원 정보 입력 및 조회 기능 반영
- 실제 투입 장비 정보 입력 및 조회 기능 반영

## :white_check_mark: 테스트 내용
- 공사일보 목록 조회 확인
- 작업일 기준 조회 확인
- 공사일보 작성 화면 동작 확인
- 명일 작업 스케줄 기본 정보 불러오기 확인
- 투입 인원 연동 확인
- 투입 장비 연동 확인

## :pushpin: 참고 사항
closed #331 