### PR TITLE
[Feat] 공정 분석 기반 지연 위험 작업 변경 요청 흐름 개선

### DIFF
--- a/src/api/aischedulerecommendation.js
+++ b/src/api/aischedulerecommendation.js
@@ -1,0 +1,23 @@
+import api from './index.js'
+
+const PATH = '/ai/schedule-recommendations'
+
+export const createAiScheduleRecommendation = (payload) => {
+  return api.post(PATH, payload, { timeout: 60000 })
+}
+
+export const fetchAiScheduleRecommendations = (projectId) => {
+  return api.get(PATH, { params: { projectId } })
+}
+
+export const fetchAiScheduleRecommendation = (id) => {
+  return api.get(`${PATH}/${id}`)
+}
+
+export const completeAiScheduleRecommendation = (id, payload) => {
+  return api.post(`${PATH}/${id}/complete`, payload)
+}
+
+export const failAiScheduleRecommendation = (id, payload) => {
+  return api.post(`${PATH}/${id}/fail`, payload)
+}

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -158,7 +158,6 @@ const siteInfoNavAll = [
 
 const documentNavAll = [
   { path: '/site/documents/upload', label: '업로드 문서', icon: Upload },
-  { path: '/site/documents/ai-history', label: 'AI 분석 이력', icon: FileText },
 ]
 
 const accountNavAll = [

--- a/src/views/schedule/AnalysisView.vue
+++ b/src/views/schedule/AnalysisView.vue
@@ -1,6 +1,10 @@
 <script setup>
-import { ref, computed, reactive, watch, onMounted } from 'vue'
+import { ref, computed, reactive, watch, onMounted, onBeforeUnmount } from 'vue'
 import { fetchProgressList, fetchDelayRiskTasks } from '@/api/analysis.js'
+import {
+  createAiScheduleRecommendation,
+  fetchAiScheduleRecommendation,
+} from '@/api/aischedulerecommendation.js'
 import {
   createScheduleChange,
   fetchScheduleChangeList,
@@ -34,6 +38,7 @@ import {
   ListChecks,
   History,
   Search,
+  LoaderCircle,
 } from 'lucide-vue-next'
 
 // ─── 권한 / 역할 ──────────────────────────────────────────────────────────
@@ -147,6 +152,7 @@ function mapProgressItem(item) {
     forecastEnd: item.forecastEnd ?? '',
     actualSource: item.actualSource ?? 'NONE',
     latestReportDate: item.latestReportDate ?? '',
+    analysisDate: item.analysisDate ?? item.latestReportDate ?? '',
     status: item.status ?? '정상',
     risk: item.risk ?? '낮음',
     partner: item.partner ?? '-',
@@ -312,6 +318,13 @@ function findDetailSchedulesForMonthly(monthlyPlanId) {
   return weeklyWorkPlans.value
     .filter((p) => Number(p.parentWorkPlanId ?? p.parent_work_plan_id ?? p.parentId ?? 0) === id)
     .sort((a, b) => String(a.startDate ?? '').localeCompare(String(b.startDate ?? '')))
+}
+
+function isActionableDetailSchedule(schedule) {
+  const id = getPlanId(schedule)
+  const requiredCount = Number(schedule?.requiredCount ?? 0)
+  const date = schedule?.startDate || schedule?.date
+  return !!id && !!date && requiredCount > 0
 }
 
 function isSameOrAfter(dateValue, baseValue) {
@@ -510,7 +523,9 @@ function buildRedistributionPlan(task) {
   const end = parseDate(task?.plannedEnd || task?.originalEnd)
   const plannedPct = clampPct(task?.plannedPct ?? 0)
   const actualPct = clampPct(task?.actualPct ?? 0)
-  const detailSchedules = Array.isArray(task?.detailSchedules) ? task.detailSchedules : []
+  const detailSchedules = (Array.isArray(task?.detailSchedules) ? task.detailSchedules : []).filter(
+    isActionableDetailSchedule,
+  )
 
   const hasTodayReport = hasTodayReportForMonthlyTask(detailSchedules)
   const beforeWorkEnd = now.getHours() < 17
@@ -751,9 +766,15 @@ function mapDelayTaskItem(item) {
     item.originalEnd ??
     item.effectiveEnd ??
     ''
-  const ended = !!(parseDate(plannedEnd) && new Date() > parseDate(plannedEnd) && actualPct < 100)
+  const analysisDate = item.analysisDate ?? item.latestReportDate ?? ''
+  const statusBaseDate = analysisDate || new Date()
+  const ended = !!(
+    parseDate(plannedEnd) &&
+    parseDate(statusBaseDate) > parseDate(plannedEnd) &&
+    actualPct < 100
+  )
   const risk = riskFromDiff(diff, ended, actualPct)
-  const status = statusFromDiff(diff, ended, actualPct, plannedStart)
+  const status = statusFromDiff(diff, ended, actualPct, plannedStart, statusBaseDate)
 
   const mapped = {
     id: item.workPlanId,
@@ -770,6 +791,7 @@ function mapDelayTaskItem(item) {
     actualPct,
     actualSource: item.actualSource ?? 'NONE',
     latestReportDate: item.latestReportDate ?? '',
+    analysisDate,
     dailyReportId: item.dailyReportId ?? null,
     diff,
     status,
@@ -876,6 +898,12 @@ onMounted(() => {
 
 // ─── AI 추천안 ──────────────────────────────────────────────────────────
 const aiRecs = reactive({})
+const aiRecommendationPollers = new Map()
+
+onBeforeUnmount(() => {
+  aiRecommendationPollers.forEach((timer) => clearInterval(timer))
+  aiRecommendationPollers.clear()
+})
 
 function buildDetailScheduleEditProposals(redistribution) {
   if (!redistribution?.days?.length) return []
@@ -1026,6 +1054,42 @@ function buildDetailedAiRecommendationText(task, redistribution, detailEditPropo
   ].join('\n')
 }
 
+function buildOperationalRecommendationText(task, redistribution, proposals = []) {
+  const shortage = Math.abs(Number(task.diff || 0)).toFixed(1)
+  const latestReportDate = task.latestReportDate || task.analysisDate || '최근 보고일'
+  const expectedDelayDays = Number(task.expectedDelayDays || 0)
+
+  if (!proposals.length) {
+    return (
+      `최신 보고일 ${latestReportDate} 기준 계획 ${task.plannedPct}%, 실제 ${task.actualPct}%로 ` +
+      `${shortage}%p 부족합니다. 현재 조정 가능한 하위 세부일정이 없어 월간 세부계획 매핑과 작업지시서 발급 상태를 먼저 확인해야 합니다.`
+    )
+  }
+
+  const ids = proposals
+    .map((proposal) => proposal.workPlanId)
+    .filter(Boolean)
+    .join(', ')
+  const dates = proposals
+    .map((proposal) => proposal.date)
+    .filter(Boolean)
+    .join(', ')
+  const targetText = proposals
+    .map(
+      (proposal) => `${proposal.date || '-'} ${proposal.normalTargetPct}%→${proposal.targetPct}%`,
+    )
+    .join(', ')
+
+  return [
+    `최신 보고일 ${latestReportDate} 기준 계획 ${task.plannedPct}%, 실제 ${task.actualPct}%로 ${shortage}%p 부족하며 예상 지연은 ${expectedDelayDays}일입니다.`,
+    `가까운 실행 가능 작업 ${ids ? `${ids}번` : ''}${dates ? `(${dates})` : ''}에 미달분을 분산 반영합니다.`,
+    `목표 진척률은 ${targetText} 기준으로 관리하고, 작업명은 기존 세부작업명을 유지한 상태에서 인력·작업시간·비고만 검토합니다.`,
+    redistribution?.normalReturnDate
+      ? `${redistribution.normalReturnDate} 이후 일정은 기존 목표율로 복귀하는 것을 기준으로 합니다.`
+      : '남은 일정은 기존 목표율 복귀를 기준으로 확인합니다.',
+  ].join('\n')
+}
+
 function ensureAiRecommendation(task) {
   if (!task?.id) return
   if (aiRecs[task.id]) return
@@ -1041,6 +1105,10 @@ function ensureAiRecommendation(task) {
       : '현재 계획 대비 미달분이 크지 않아 남은 세부일정은 기존 목표 중심으로 관리합니다.'
 
   aiRecs[task.id] = {
+    source: 'RULE_FALLBACK',
+    aiStatus: 'READY',
+    aiError: '',
+    recommendationId: null,
     summary:
       `${task.name} 월간 세부계획은 현재 계획 대비 ${diffText} 상태입니다. ` +
       `종료일(${task.originalEnd || task.plannedEnd || '-'})은 우선 유지하고, 전체 남은 기간에 균등 분산하기보다 ${catchUpText}`,
@@ -1063,6 +1131,377 @@ function ensureAiRecommendation(task) {
 }
 
 // ─── 일정 변경 요청 ──────────────────────────────────────────────────────
+function isPlainObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function parseMaybeJson(value) {
+  if (typeof value !== 'string') return value
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+function unwrapAiApiData(response) {
+  if (!isPlainObject(response)) return response
+  if (
+    'data' in response &&
+    ('success' in response || 'isSuccess' in response || 'code' in response)
+  ) {
+    return response.data
+  }
+  return response
+}
+
+function pickText(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+function pickNumber(value, fallback = 0) {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : fallback
+}
+
+function readAiResultParts(record) {
+  const result = parseMaybeJson(record?.result ?? record ?? {})
+  const resultObject = isPlainObject(result) ? result : {}
+  const nestedRecommendation = isPlainObject(resultObject.recommendation)
+    ? resultObject.recommendation
+    : {}
+  const body = { ...resultObject, ...nestedRecommendation }
+  const changeSummary = isPlainObject(body.changeSummary)
+    ? body.changeSummary
+    : isPlainObject(resultObject.changeSummary)
+      ? resultObject.changeSummary
+      : {}
+  const detailChanges = Array.isArray(body.detailChanges)
+    ? body.detailChanges
+    : Array.isArray(resultObject.detailChanges)
+      ? resultObject.detailChanges
+      : []
+
+  return {
+    result,
+    resultObject,
+    body,
+    changeSummary,
+    detailChanges,
+  }
+}
+
+function findFallbackProposal(task, change, index = 0) {
+  const proposals = aiRecs[task.id]?.detailEditProposals || []
+  const workPlanId = Number(change?.workPlanId ?? 0)
+  if (workPlanId) {
+    const byId = proposals.find((proposal) => Number(proposal.workPlanId || 0) === workPlanId)
+    if (byId) return byId
+  }
+  return proposals[index] || {}
+}
+
+function normalizeAiDetailProposal(task, change, index = 0) {
+  change = isPlainObject(change) ? change : {}
+  const fallback = findFallbackProposal(task, change, index)
+  const originalRequiredCount = pickNumber(
+    change.originalRequiredCount,
+    pickNumber(fallback.originalRequiredCount, 0),
+  )
+  const recommendedRequiredCount = pickNumber(
+    change.recommendedRequiredCount,
+    pickNumber(fallback.recommendedRequiredCount, originalRequiredCount),
+  )
+
+  const proposal = {
+    workPlanId: pickNumber(change.workPlanId, pickNumber(fallback.workPlanId, 0)),
+    date: pickText(change.date, fallback.date),
+    location: pickText(change.location, fallback.location),
+    originalName: pickText(change.originalName, fallback.originalName, task.name),
+    recommendedName: pickText(
+      change.recommendedName,
+      fallback.recommendedName,
+      change.originalName,
+      fallback.originalName,
+      task.name,
+    ),
+    originalRequiredCount,
+    recommendedRequiredCount,
+    normalTargetPct: change.normalTargetPct ?? fallback.normalTargetPct,
+    targetPct: change.targetPct ?? fallback.targetPct,
+    catchUpPct: change.catchUpPct ?? fallback.catchUpPct,
+    carryOver: Boolean(change.carryOver ?? fallback.carryOver),
+    originalNote: pickText(change.originalNote, fallback.originalNote),
+    recommendedNote: pickText(
+      change.recommendedNote,
+      fallback.recommendedNote,
+      change.reason,
+      change.note,
+    ),
+    originalWorkTime: pickText(change.originalWorkTime, fallback.originalWorkTime),
+    recommendedWorkTime: pickText(
+      change.recommendedWorkTime,
+      fallback.recommendedWorkTime,
+      change.workTime,
+    ),
+    originalWorkHours: pickNumber(
+      change.originalWorkHours,
+      pickNumber(fallback.originalWorkHours, 0),
+    ),
+    recommendedWorkHours: pickNumber(
+      change.recommendedWorkHours,
+      pickNumber(fallback.recommendedWorkHours, 0),
+    ),
+    originalManHours: pickNumber(change.originalManHours, pickNumber(fallback.originalManHours, 0)),
+    recommendedManHours: pickNumber(
+      change.recommendedManHours,
+      pickNumber(fallback.recommendedManHours, 0),
+    ),
+    additionalManHours: pickNumber(
+      change.additionalManHours,
+      pickNumber(fallback.additionalManHours, 0),
+    ),
+    addedWorkers: pickNumber(change.addedWorkers, pickNumber(fallback.addedWorkers, 0)),
+    addedWorkHours: pickNumber(change.addedWorkHours, pickNumber(fallback.addedWorkHours, 0)),
+    manHourAdjustmentReason: pickText(
+      change.manHourAdjustmentReason,
+      change.reason,
+      fallback.manHourAdjustmentReason,
+    ),
+    trade: pickText(change.trade, fallback.trade, task.process),
+    partner: pickText(change.partner, fallback.partner),
+    manager: pickText(change.manager, fallback.manager),
+    contact: pickText(change.contact, fallback.contact),
+    parentWorkPlanId:
+      change.parentWorkPlanId ?? fallback.parentWorkPlanId ?? task.monthlyWorkPlanId ?? null,
+    tradeProcessId: change.tradeProcessId ?? fallback.tradeProcessId ?? null,
+    isEditing: false,
+    isUserEdited: false,
+  }
+
+  refreshProposalManHours(proposal)
+  return proposal
+}
+
+function setAiRecommendationError(taskId, message) {
+  if (!taskId || !aiRecs[taskId]) return
+  aiRecs[taskId].aiStatus = 'FAILED'
+  aiRecs[taskId].aiError = message || 'AI 추천 생성에 실패했습니다.'
+}
+
+function stopAiRecommendationPolling(taskId) {
+  const timer = aiRecommendationPollers.get(taskId)
+  if (!timer) return
+  clearInterval(timer)
+  aiRecommendationPollers.delete(taskId)
+}
+
+function applyAiRecommendationRecordToTask(taskId, rawRecord) {
+  const task = delayTasks.value.find((item) => item.id === taskId)
+  if (!task) return
+
+  ensureAiRecommendation(task)
+
+  const record = unwrapAiApiData(rawRecord) || {}
+  const previous = aiRecs[task.id] || {}
+  const { resultObject, body, changeSummary, detailChanges } = readAiResultParts(record)
+  const fallbackProposals = previous.detailEditProposals || []
+  const allowedWorkPlanIds = new Set(
+    fallbackProposals.map((proposal) => Number(proposal.workPlanId || 0)).filter(Boolean),
+  )
+  const aiProposals = detailChanges.length
+    ? detailChanges
+        .map((change, index) => normalizeAiDetailProposal(task, change, index))
+        .filter((proposal) => {
+          const workPlanId = Number(proposal.workPlanId || 0)
+          if (!workPlanId || !allowedWorkPlanIds.has(workPlanId)) return false
+          return Number(proposal.originalRequiredCount || 0) > 0
+        })
+        .slice(0, Math.max(1, fallbackProposals.length))
+    : []
+  const aiProposalById = new Map(
+    aiProposals.map((proposal) => [Number(proposal.workPlanId || 0), proposal]),
+  )
+  const normalizedProposals = fallbackProposals.length
+    ? fallbackProposals.map((fallback) => {
+        const aiProposal = aiProposalById.get(Number(fallback.workPlanId || 0))
+        if (!aiProposal) return fallback
+
+        const originalRequiredCount = Number(fallback.originalRequiredCount || 0)
+        const maxRecommendedCount =
+          originalRequiredCount + Math.max(2, Math.ceil(originalRequiredCount * 0.3))
+        const aiRecommendedCount = pickNumber(
+          aiProposal.recommendedRequiredCount,
+          pickNumber(fallback.recommendedRequiredCount, originalRequiredCount),
+        )
+        const aiRecommendedName = pickText(aiProposal.recommendedName, fallback.recommendedName)
+        const recommendedName =
+          aiRecommendedName.includes(fallback.originalName) ||
+          aiRecommendedName === fallback.originalName
+            ? aiRecommendedName
+            : fallback.recommendedName
+
+        const merged = {
+          ...fallback,
+          recommendedName,
+          recommendedRequiredCount: Math.max(
+            originalRequiredCount,
+            Math.min(maxRecommendedCount, aiRecommendedCount),
+          ),
+          recommendedWorkTime: pickText(
+            aiProposal.recommendedWorkTime,
+            fallback.recommendedWorkTime,
+          ),
+          recommendedNote: pickText(aiProposal.recommendedNote, fallback.recommendedNote),
+          manHourAdjustmentReason: pickText(
+            aiProposal.manHourAdjustmentReason,
+            fallback.manHourAdjustmentReason,
+          ),
+          isEditing: false,
+          isUserEdited: false,
+        }
+        refreshProposalManHours(merged)
+        return merged
+      })
+    : aiProposals
+  const maxAddedWorkers = normalizedProposals.reduce(
+    (max, proposal) =>
+      Math.max(
+        max,
+        Number(proposal.recommendedRequiredCount || 0) -
+          Number(proposal.originalRequiredCount || 0),
+      ),
+    0,
+  )
+
+  aiRecs[task.id] = {
+    ...previous,
+    source: 'AI',
+    aiStatus: 'SUCCESS',
+    aiError: '',
+    recommendationId:
+      record.idx ?? record.id ?? record.recommendationId ?? previous.recommendationId,
+    summary: pickText(body.summary, body.summaryText, changeSummary.summary, previous.summary),
+    recommendation: pickText(
+      buildOperationalRecommendationText(task, previous.redistribution, normalizedProposals),
+      previous.recommendation,
+    ),
+    workerSuggestion: pickText(
+      body.workerSuggestion,
+      changeSummary.workerSuggestion,
+      previous.workerSuggestion,
+    ),
+    affectedTasks: Array.isArray(body.affectedTasks)
+      ? body.affectedTasks
+      : previous.affectedTasks || [],
+    redistribution: previous.redistribution,
+    detailEditProposals: normalizedProposals,
+    editedAddDays: pickNumber(changeSummary.addDays, pickNumber(previous.editedAddDays, 0)),
+    editedWorkers: pickNumber(
+      body.editedWorkers ?? changeSummary.recommendedWorkers,
+      pickNumber(previous.editedWorkers, maxAddedWorkers),
+    ),
+    expectedEffect: pickText(
+      body.expectedEffect,
+      changeSummary.expectedEffect,
+      previous.expectedEffect,
+    ),
+  }
+}
+
+function startAiRecommendationPolling(taskId, recommendationId) {
+  stopAiRecommendationPolling(taskId)
+
+  let attempts = 0
+  const timer = setInterval(async () => {
+    attempts += 1
+    try {
+      const record = unwrapAiApiData(await fetchAiScheduleRecommendation(recommendationId))
+      const status = String(record?.status || '').toUpperCase()
+
+      if (status === 'SUCCESS') {
+        stopAiRecommendationPolling(taskId)
+        applyAiRecommendationRecordToTask(taskId, record)
+        return
+      }
+
+      if (status === 'FAILED') {
+        stopAiRecommendationPolling(taskId)
+        setAiRecommendationError(taskId, record?.errorMessage || 'AI 추천 생성에 실패했습니다.')
+        return
+      }
+
+      if (attempts >= 60) {
+        stopAiRecommendationPolling(taskId)
+        setAiRecommendationError(
+          taskId,
+          'AI 추천 생성이 지연되고 있습니다. 잠시 후 다시 시도해 주세요.',
+        )
+      }
+    } catch (err) {
+      if (attempts >= 60) {
+        stopAiRecommendationPolling(taskId)
+        setAiRecommendationError(taskId, err?.message || 'AI 추천 상태 조회에 실패했습니다.')
+      }
+    }
+  }, 2500)
+
+  aiRecommendationPollers.set(taskId, timer)
+}
+
+async function requestAiRecommendationForSelectedTask() {
+  const task = selectedTask.value
+  if (!task?.id) return
+
+  ensureAiRecommendation(task)
+  const rec = aiRecs[task.id]
+  const monthlyWorkPlanId = Number(task.monthlyWorkPlanId || task.workPlanId || task.id || 0)
+
+  if (!monthlyWorkPlanId) {
+    setAiRecommendationError(task.id, '월간 세부계획 ID가 없어 AI 추천을 요청할 수 없습니다.')
+    return
+  }
+
+  try {
+    stopAiRecommendationPolling(task.id)
+    rec.source = 'AI'
+    rec.aiStatus = 'PENDING'
+    rec.aiError = ''
+
+    const created = unwrapAiApiData(
+      await createAiScheduleRecommendation({
+        projectId: PROJECT_ID,
+        monthlyWorkPlanId,
+      }),
+    )
+    const recommendationId = Number(created?.idx ?? created?.id ?? created?.recommendationId ?? 0)
+    rec.recommendationId = recommendationId || null
+
+    const status = String(created?.status || '').toUpperCase()
+    if (status === 'SUCCESS') {
+      applyAiRecommendationRecordToTask(task.id, created)
+      return
+    }
+
+    if (status === 'FAILED') {
+      setAiRecommendationError(task.id, created?.errorMessage || 'AI 추천 생성에 실패했습니다.')
+      return
+    }
+
+    if (!recommendationId) {
+      throw new Error('AI 추천 요청 ID를 받지 못했습니다.')
+    }
+
+    startAiRecommendationPolling(task.id, recommendationId)
+  } catch (err) {
+    console.error('AI schedule recommendation failed:', err)
+    setAiRecommendationError(task.id, err?.message || 'AI 추천 생성에 실패했습니다.')
+  }
+}
+
 const changeRequests = ref([])
 const changeHistory = ref([])
 
@@ -1119,7 +1558,10 @@ function mapScheduleChange(item, historyMode = false) {
     oldEnd: item.oldEnd || '',
     newStart: item.newStart || '',
     newEnd: item.newEnd || '',
-    reason: historyMode && status === 'rejected' ? item.rejectReason || item.reason || '' : item.reason || '',
+    reason:
+      historyMode && status === 'rejected'
+        ? item.rejectReason || item.reason || ''
+        : item.reason || '',
     changeSummary: item.changeSummary || null,
     detailChanges: Array.isArray(item.detailChanges) ? item.detailChanges : [],
     aiApplied: !!item.aiApplied,
@@ -1138,7 +1580,10 @@ function mapScheduleChange(item, historyMode = false) {
 function scheduleChangeDedupeKey(item, includeStatus = false) {
   const detailIds = Array.isArray(item.detailChanges)
     ? item.detailChanges
-        .map((detail) => detail.workPlanId || detail.date || detail.originalName || detail.recommendedName)
+        .map(
+          (detail) =>
+            detail.workPlanId || detail.date || detail.originalName || detail.recommendedName,
+        )
         .filter(Boolean)
         .join(',')
     : ''
@@ -1185,7 +1630,9 @@ async function loadScheduleChangeData() {
 
   const activeStatuses = new Set(['pending', 'approved'])
   const requestItems = Array.isArray(requests)
-    ? requests.map((item) => mapScheduleChange(item, false)).filter((item) => activeStatuses.has(item.status))
+    ? requests
+        .map((item) => mapScheduleChange(item, false))
+        .filter((item) => activeStatuses.has(item.status))
     : []
   const historyItems = Array.isArray(history)
     ? history.map((item) => mapScheduleChange(item, true))
@@ -1463,9 +1910,7 @@ async function submitRequest() {
     changeSummary: clonePlain(requestForm.changeSummary),
     detailChanges,
     aiApplied: requestForm.aiApplied,
-    attachmentUrls: requestForm.attachments
-      .map((file) => file.url || file.name)
-      .filter(Boolean),
+    attachmentUrls: requestForm.attachments.map((file) => file.url || file.name).filter(Boolean),
   })
 
   await loadScheduleChangeData()
@@ -1609,6 +2054,15 @@ const aiQuickSummary = computed(() => {
   const workerChanges = proposals.filter(
     (p) => p.recommendedRequiredCount !== p.originalRequiredCount,
   )
+  const totalAdditionalWorkers = workerChanges.reduce(
+    (sum, p) =>
+      sum +
+      Math.max(
+        0,
+        Number(p.recommendedRequiredCount || 0) - Number(p.originalRequiredCount || 0),
+      ),
+    0,
+  )
 
   // 대표 변경(첫 proposal) 정보
   const sample = proposals[0] || null
@@ -1621,11 +2075,13 @@ const aiQuickSummary = computed(() => {
 
   return {
     proposalCount,
+    proposals,
     oldEnd,
     newEnd,
     addDays: rec.editedAddDays || 0,
     workTimeChanges,
     workerChanges,
+    totalAdditionalWorkers,
     sample,
     totalAdditionalManHours: Math.round(totalAdditionalManHours * 10) / 10,
   }
@@ -1901,9 +2357,6 @@ function addDaysStr(dateStr, n) {
       <div>
         <p class="text-[11px] font-bold uppercase tracking-widest text-flare-600">일정 관리</p>
         <h1 class="text-xl font-bold text-forena-900">공정 분석</h1>
-        <p class="mt-1 text-xs text-forena-500">
-          공종별 진척률을 한눈에 보고, AI 추천을 바탕으로 일정을 조정하세요
-        </p>
       </div>
       <div class="flex flex-wrap items-center gap-2">
         <!-- 공종별 권한 선택 -->
@@ -2346,9 +2799,27 @@ function addDaysStr(dateStr, n) {
                   작업 일정 조정 — {{ selectedTask.name }}
                 </p>
               </div>
-              <button @click="selectedTaskId = null" class="text-forena-400 hover:text-forena-700">
-                <X class="h-4 w-4" />
-              </button>
+              <div class="flex items-center gap-2">
+                <button
+                  type="button"
+                  :disabled="selectedRec.aiStatus === 'PENDING'"
+                  class="inline-flex items-center gap-1.5 rounded-lg border border-cyan-200 bg-white px-3 py-1.5 text-[11px] font-bold text-cyan-700 transition-colors hover:bg-cyan-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  @click="requestAiRecommendationForSelectedTask"
+                >
+                  <LoaderCircle
+                    v-if="selectedRec.aiStatus === 'PENDING'"
+                    class="h-3.5 w-3.5 animate-spin"
+                  />
+                  <Sparkles v-else class="h-3.5 w-3.5" />
+                  {{ selectedRec.source === 'AI' ? 'AI 재생성' : 'AI 추천 생성' }}
+                </button>
+                <button
+                  @click="selectedTaskId = null"
+                  class="text-forena-400 hover:text-forena-700"
+                >
+                  <X class="h-4 w-4" />
+                </button>
+              </div>
             </div>
             <div class="space-y-4 p-4">
               <!-- 핵심 지표 요약 -->
@@ -2397,6 +2868,21 @@ function addDaysStr(dateStr, n) {
               </div>
 
               <!-- 가장 중요한 영역: 실제 수정안 -->
+              <div
+                v-if="selectedRec.aiStatus === 'PENDING'"
+                class="flex items-center gap-2 rounded-lg border border-cyan-100 bg-cyan-50 px-3.5 py-3 text-xs font-semibold text-cyan-800"
+              >
+                <LoaderCircle class="h-4 w-4 animate-spin" />
+                OpenAI 추천안을 생성하는 중입니다. 완료되면 아래 수정안이 AI 결과로 갱신됩니다.
+              </div>
+
+              <div
+                v-if="selectedRec.aiError"
+                class="rounded-lg border border-rose-100 bg-rose-50 px-3.5 py-3 text-xs font-semibold text-rose-700"
+              >
+                {{ selectedRec.aiError }}
+              </div>
+
               <div
                 v-if="selectedRec.detailEditProposals?.length"
                 class="rounded-xl border border-cyan-200 bg-cyan-50/30 p-4"
@@ -2613,7 +3099,7 @@ function addDaysStr(dateStr, n) {
               </div>
 
               <div
-                v-if="isSupervisor"
+                v-if="false"
                 class="rounded-lg border border-forena-100 bg-forena-50/60 px-3.5 py-3 text-xs text-forena-500"
               >
                 AI 추천안은 참고용입니다. 일정 변경은 공정 책임자 요청 → 총 책임자 승인 → 일정 반영
@@ -3233,7 +3719,7 @@ function addDaysStr(dateStr, n) {
 
               <div class="space-y-2 px-3.5 py-3">
                 <!-- 종료일 변경 -->
-                <div class="flex items-center gap-2 text-xs">
+                <div v-if="aiQuickSummary.addDays !== 0" class="flex items-center gap-2 text-xs">
                   <Clock class="h-3.5 w-3.5 shrink-0 text-flare-600" />
                   <span class="w-16 shrink-0 font-bold text-forena-500">종료일</span>
                   <span
@@ -3266,7 +3752,22 @@ function addDaysStr(dateStr, n) {
 
                 <!-- 인력 변경 -->
                 <div
-                  v-if="aiQuickSummary.workerChanges.length"
+                  v-if="aiQuickSummary.workerChanges.length > 1"
+                  class="flex items-center gap-2 text-xs"
+                >
+                  <UserCog class="h-3.5 w-3.5 shrink-0 text-flare-600" />
+                  <span class="w-16 shrink-0 font-bold text-forena-500">투입 인력</span>
+                  <span class="font-extrabold text-forena-800">
+                    세부일정 {{ aiQuickSummary.workerChanges.length }}건 변경
+                  </span>
+                  <span
+                    class="ml-auto rounded bg-white px-1.5 py-0.5 text-[10px] font-extrabold tabular-nums text-flare-700 ring-1 ring-flare-300"
+                  >
+                    +{{ aiQuickSummary.totalAdditionalWorkers }}명
+                  </span>
+                </div>
+                <div
+                  v-if="aiQuickSummary.workerChanges.length === 1"
                   class="flex items-center gap-2 text-xs"
                 >
                   <UserCog class="h-3.5 w-3.5 shrink-0 text-flare-600" />
@@ -3296,7 +3797,17 @@ function addDaysStr(dateStr, n) {
 
                 <!-- 작업시간 변경 -->
                 <div
-                  v-if="aiQuickSummary.workTimeChanges.length"
+                  v-if="aiQuickSummary.workTimeChanges.length > 1"
+                  class="flex items-center gap-2 text-xs"
+                >
+                  <Activity class="h-3.5 w-3.5 shrink-0 text-flare-600" />
+                  <span class="w-16 shrink-0 font-bold text-forena-500">작업시간</span>
+                  <span class="font-extrabold text-forena-800">
+                    세부일정 {{ aiQuickSummary.workTimeChanges.length }}건 변경
+                  </span>
+                </div>
+                <div
+                  v-if="aiQuickSummary.workTimeChanges.length === 1"
                   class="flex items-center gap-2 text-xs"
                 >
                   <Activity class="h-3.5 w-3.5 shrink-0 text-flare-600" />
@@ -3331,7 +3842,59 @@ function addDaysStr(dateStr, n) {
 
               <!-- 대표 세부일정 정보 -->
               <div
-                v-if="aiQuickSummary.sample && aiQuickSummary.proposalCount > 1"
+                v-if="aiQuickSummary.proposals && aiQuickSummary.proposals.length"
+                class="border-t border-flare-100 bg-white/70 px-3.5 py-3"
+              >
+                <p class="mb-2 text-[10px] font-extrabold uppercase tracking-wide text-forena-500">
+                  변경 대상 세부일정
+                </p>
+                <div class="space-y-2">
+                  <div
+                    v-for="(proposal, index) in aiQuickSummary.proposals"
+                    :key="proposal.workPlanId || `${proposal.date}-${index}`"
+                    class="rounded-lg border border-forena-100 bg-white px-3 py-2"
+                  >
+                    <div class="flex items-start gap-2">
+                      <span
+                        class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-flare-50 text-[10px] font-extrabold tabular-nums text-flare-700 ring-1 ring-flare-200"
+                      >
+                        {{ index + 1 }}
+                      </span>
+                      <div class="min-w-0">
+                        <p class="truncate text-xs font-extrabold text-forena-900">
+                          {{ proposal.date }} · {{ proposal.originalName }}
+                        </p>
+                        <p class="mt-0.5 truncate text-[10px] text-forena-500">
+                          {{ proposal.location || selectedTask.location || '-' }}
+                        </p>
+                      </div>
+                    </div>
+                    <div class="mt-2 grid grid-cols-1 gap-1.5 text-[11px] sm:grid-cols-3">
+                      <p class="tabular-nums text-forena-600">
+                        인력
+                        <span class="font-bold text-forena-800">
+                          {{ proposal.originalRequiredCount }}명 → {{ proposal.recommendedRequiredCount }}명
+                        </span>
+                      </p>
+                      <p class="tabular-nums text-forena-600">
+                        시간
+                        <span class="font-bold text-forena-800">
+                          {{ proposal.originalWorkTime || '-' }} → {{ proposal.recommendedWorkTime || '-' }}
+                        </span>
+                      </p>
+                      <p class="tabular-nums text-forena-600">
+                        공수
+                        <span class="font-bold text-flare-700">
+                          +{{ Math.round(Number(proposal.additionalManHours || 0) * 10) / 10 }}인시
+                        </span>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div
+                v-if="false"
                 class="border-t border-flare-100 bg-white/60 px-3.5 py-2"
               >
                 <p class="text-[10px] text-forena-500">

--- a/src/views/schedule/DailyWorkReportView.vue
+++ b/src/views/schedule/DailyWorkReportView.vue
@@ -3,13 +3,16 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import api from '@/api/index'
 import {
+  fetchScheduleChangeHistory,
+  fetchScheduleChangeList,
+} from '@/api/schedulechange.js'
+import {
   CalendarDays,
   ChevronLeft,
   ChevronRight,
   FileText,
   Plus,
   Save,
-  Upload,
   Image as ImageIcon,
   Paperclip,
   X,
@@ -23,13 +26,10 @@ import {
   Send,
   Eye,
   Pencil,
-  FileCheck2,
   Layers,
   ShieldCheck,
   UserCog,
   Trash2,
-  Download,
-  Sparkles,
 } from 'lucide-vue-next'
 
 // feat : 사용자 권한 상수 정의
@@ -37,6 +37,8 @@ const ROLES = {
   MANAGER: 'site_manager',
   WORKER: 'process_owner',
 }
+
+const PROJECT_ID = 1
 
 const currentRole = ref(ROLES.WORKER)
 const ALL_PROCESSES = [
@@ -221,8 +223,56 @@ function fmtKor(dateStr) {
   return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일 (${dow})`
 }
 
+function toDateString(dateVal) {
+  if (Array.isArray(dateVal)) {
+    return `${dateVal[0]}-${String(dateVal[1]).padStart(2, '0')}-${String(dateVal[2]).padStart(2, '0')}`
+  }
+  return dateVal ? String(dateVal).slice(0, 10) : ''
+}
+
+function toNumberOrNull(value) {
+  if (value === null || value === undefined || value === '') return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+function getPlanId(record) {
+  const id = Number(record?.idx ?? record?.id ?? record?.workPlanId)
+  return Number.isFinite(id) ? id : null
+}
+
+function getPlanDate(record) {
+  return toDateString(record?.startDate || record?.date || record?.reportDate)
+}
+
+function unwrapApiList(res) {
+  if (Array.isArray(res)) return res
+  if (Array.isArray(res?.data)) return res.data
+  if (Array.isArray(res?.data?.data)) return res.data.data
+  return []
+}
+
+function normalizeScheduleChangeStatus(status) {
+  const value = String(status || '').trim().toLowerCase()
+  if (['approved', '승인 완료', '승인완료'].includes(value)) return 'approved'
+  if (['applied', '일정 반영 완료', '일정반영완료', '반영 완료', '반영완료'].includes(value))
+    return 'applied'
+  if (['pending', '승인 대기', '승인대기'].includes(value)) return 'pending'
+  if (['rejected', '반려'].includes(value)) return 'rejected'
+  return value
+}
+
+function parseScheduleTime(value) {
+  if (Array.isArray(value)) {
+    const [year, month, day, hour = 0, minute = 0, second = 0] = value
+    return new Date(year, month - 1, day, hour, minute, second).getTime()
+  }
+  if (!value) return 0
+  const time = new Date(value).getTime()
+  return Number.isFinite(time) ? time : 0
+}
+
 const selectedDate = ref(todayStr())
-const tomorrowDate = computed(() => addDays(selectedDate.value, 1))
 function prevDay() {
   selectedDate.value = addDays(selectedDate.value, -1)
 }
@@ -235,7 +285,6 @@ function goToday() {
 const isToday = computed(() => selectedDate.value === todayStr())
 
 const activeTab = ref('today')
-const modalTab = ref('today')
 
 function switchTab(tab) {
   if (tab === 'consolidated' && currentRole.value !== ROLES.MANAGER) return
@@ -248,6 +297,162 @@ function switchRole(role) {
 }
 
 const reports = ref([])
+const approvedScheduleChanges = ref([])
+
+async function loadApprovedScheduleChanges() {
+  try {
+    const [listRes, historyRes] = await Promise.all([
+      fetchScheduleChangeList({ projectId: PROJECT_ID }),
+      fetchScheduleChangeHistory({ projectId: PROJECT_ID }),
+    ])
+
+    approvedScheduleChanges.value = [...unwrapApiList(listRes), ...unwrapApiList(historyRes)]
+  } catch (error) {
+    console.error('승인 일정 변경 조회 실패:', error)
+    approvedScheduleChanges.value = []
+  }
+}
+
+function findApprovedScheduleTarget(workPlanId, workDate) {
+  const id = Number(workPlanId)
+  if (!Number.isFinite(id)) return null
+
+  const candidates = []
+
+  approvedScheduleChanges.value.forEach((request) => {
+    const status = normalizeScheduleChangeStatus(request.status)
+    if (!['approved', 'applied'].includes(status)) return
+
+    const details = Array.isArray(request.detailChanges) ? request.detailChanges : []
+    details.forEach((detail) => {
+      if (Number(detail.workPlanId) !== id) return
+
+      const detailDate = toDateString(detail.date)
+      if (detailDate && detailDate !== workDate) return
+
+      const targetPct = toNumberOrNull(
+        detail.targetPct ??
+          detail.recommendedTargetPct ??
+          detail.focusedTargetRate ??
+          detail.dailyTargetPct,
+      )
+      if (!targetPct || targetPct <= 0) return
+
+      const normalTargetPct = toNumberOrNull(
+        detail.normalTargetPct ?? detail.originalTargetPct ?? detail.baseTargetPct,
+      )
+
+      candidates.push({
+        requestId: request.idx ?? request.id ?? 0,
+        status,
+        targetPct,
+        normalTargetPct,
+        processedAt: parseScheduleTime(request.processedAt),
+        requestDate: parseScheduleTime(request.requestDate),
+      })
+    })
+  })
+
+  if (!candidates.length) return null
+
+  candidates.sort((a, b) => {
+    const timeDiff =
+      Math.max(b.processedAt, b.requestDate) - Math.max(a.processedAt, a.requestDate)
+    if (timeDiff) return timeDiff
+    if (Number(b.requestId) !== Number(a.requestId)) return Number(b.requestId) - Number(a.requestId)
+    const statusWeight = { applied: 2, approved: 1 }
+    return (statusWeight[b.status] || 0) - (statusWeight[a.status] || 0)
+  })
+
+  return candidates[0]
+}
+
+function applyApprovedScheduleTarget() {
+  const report = editingReport.value
+  if (!report) return
+
+  const match = findApprovedScheduleTarget(report.workPlanId, report.date)
+  report.approvedDailyTargetPct = match?.targetPct ?? null
+  report.normalDailyTargetPct = match?.normalTargetPct ?? null
+  report.dailyTargetSource = match ? 'schedule_change' : 'duration'
+}
+
+function applyMonthlyScheduleWeights(childPlans = []) {
+  const report = editingReport.value
+  if (!report) return
+
+  report.scheduleWeightPct = null
+  report.normalScheduleWeightPct = null
+  report.remainingScheduleWeightPct = null
+  report.monthlyScheduleCount = 0
+  report.scheduleWeightSource = report.dailyTargetSource || 'duration'
+
+  const monthlyPlanId = Number(report.monthlyWorkPlanId)
+  const currentWorkPlanId = Number(report.workPlanId)
+  const start = new Date(report.startDate)
+  const end = new Date(report.endDate)
+  if (
+    !Number.isFinite(monthlyPlanId) ||
+    !Number.isFinite(currentWorkPlanId) ||
+    isNaN(start.getTime()) ||
+    isNaN(end.getTime())
+  ) {
+    return
+  }
+
+  const duration = Math.max(1, Math.round((end - start) / 86400000) + 1)
+  const normalDailyWeight = 100 / duration
+
+  const monthlyChildren = childPlans
+    .filter((plan) => Number(plan?.parentWorkPlanId) === monthlyPlanId)
+    .map((plan) => ({
+      id: getPlanId(plan),
+      date: getPlanDate(plan),
+    }))
+    .filter((plan) => plan.id && plan.date)
+
+  if (!monthlyChildren.length) return
+
+  const countsByDate = new Map()
+  monthlyChildren.forEach((plan) => {
+    countsByDate.set(plan.date, (countsByDate.get(plan.date) || 0) + 1)
+  })
+
+  const scheduleWeights = monthlyChildren.map((plan) => {
+    const defaultWeight = normalDailyWeight / Math.max(1, countsByDate.get(plan.date) || 1)
+    const approvedTarget = findApprovedScheduleTarget(plan.id, plan.date)
+    return {
+      ...plan,
+      weightPct: approvedTarget?.targetPct ?? defaultWeight,
+      normalWeightPct: approvedTarget?.normalTargetPct ?? defaultWeight,
+      source: approvedTarget ? 'schedule_change' : 'duration',
+    }
+  })
+
+  const reportedWorkPlanIds = new Set(
+    reports.value
+      .filter((item) => item.date === report.date)
+      .map((item) => Number(item.workPlanId))
+      .filter((id) => Number.isFinite(id) && id !== currentWorkPlanId),
+  )
+
+  const currentWeight = scheduleWeights.find((plan) => plan.id === currentWorkPlanId)
+  if (!currentWeight) return
+
+  const remainingWeightPct = scheduleWeights
+    .filter((plan) => {
+      if (plan.id === currentWorkPlanId) return false
+      if (reportedWorkPlanIds.has(plan.id)) return false
+      return plan.date >= report.date
+    })
+    .reduce((sum, plan) => sum + Number(plan.weightPct || 0), 0)
+
+  report.scheduleWeightPct = currentWeight.weightPct
+  report.normalScheduleWeightPct = currentWeight.normalWeightPct
+  report.remainingScheduleWeightPct = remainingWeightPct
+  report.monthlyScheduleCount = monthlyChildren.length
+  report.scheduleWeightSource = currentWeight.source
+}
 
 // feat : 공사일보 조회
 async function loadReportsForDate(targetDate) {
@@ -267,11 +472,10 @@ async function loadReportsForDate(targetDate) {
       date: toDateString(db.reportDate),
       process: getTradeNameFromRecord(db) || '공종 미지정',
       workers: db.actualWorkerCount || 0,
-      location: db.location || '',
+      location: db.location || db.workPlanLocation || '',
       equipmentCount: 0,
       equipmentList: [],
       todayWork: db.todayWork || '',
-      tomorrowPlan: db.tomorrowPlan || '',
       progress: db.todayProgress || 0,
       processProgress: db.actualProgress || 0,
       notes: db.issue || '',
@@ -287,11 +491,13 @@ async function loadReportsForDate(targetDate) {
 
 onMounted(() => {
   loadReportsForDate(selectedDate.value)
+  loadApprovedScheduleChanges()
   document.addEventListener('keydown', onKeydown)
 })
 
 watch(selectedDate, (newDate) => {
   loadReportsForDate(newDate)
+  loadApprovedScheduleChanges()
 })
 
 const STATUS_META = {
@@ -318,7 +524,6 @@ function reportsForDate(dateStr) {
 }
 
 const todayReports = computed(() => reportsForDate(selectedDate.value))
-const tomorrowReports = computed(() => reportsForDate(tomorrowDate.value))
 
 const stats = computed(() => {
   const list = todayReports.value
@@ -342,7 +547,6 @@ const isNewReport = ref(false)
 
 const showTaskSelector = ref(false)
 const availableTodayOrders = ref([])
-const availableTomorrowPlans = ref([])
 
 function canEdit(report) {
   if (currentRole.value === ROLES.MANAGER) return false
@@ -413,21 +617,21 @@ async function selectTaskForReport(order) {
     monthlyWorkPlanId: null,
     monthlyWorkPlanName: '',
     todayMonthlyOrderCount: 1,
-    tomorrowWorkPlanId: null,
-    tomorrowLocation: order.location || '',
-    tomorrowWorkers: 0,
-    tomorrowEquipmentList: [],
-    tomorrowEquipmentInput: { name: '', count: 1 },
-    tomorrowPlan: '',
-    tomorrowSafety: '',
+    approvedDailyTargetPct: null,
+    normalDailyTargetPct: null,
+    dailyTargetSource: 'duration',
+    scheduleWeightPct: null,
+    normalScheduleWeightPct: null,
+    remainingScheduleWeightPct: null,
+    monthlyScheduleCount: 0,
+    scheduleWeightSource: 'duration',
   }
 
   try {
     // 1. 전체 월간 세부계획 기간(철근 전체)을 구하기 위해 모든 계획을 불러옵니다.
-    const [weekRes, monthRes, yearRes] = await Promise.all([
+    const [weekRes, monthRes] = await Promise.all([
       api.get('/work-plan', { params: { planType: '주간' } }).catch(() => ({ data: [] })),
       api.get('/work-plan', { params: { planType: '월간' } }).catch(() => ({ data: [] })),
-      api.get('/work-plan', { params: { planType: '연간' } }).catch(() => ({ data: [] })),
     ])
 
     const weeklyPlans = Array.isArray(weekRes) ? weekRes : weekRes.data?.data || weekRes.data || []
@@ -435,10 +639,6 @@ async function selectTaskForReport(order) {
     const monthlyPlans = Array.isArray(monthRes)
       ? monthRes
       : monthRes.data?.data || monthRes.data || []
-
-    const yearlyPlans = Array.isArray(yearRes) ? yearRes : yearRes.data?.data || yearRes.data || []
-
-    const allPlans = [...weeklyPlans, ...monthlyPlans, ...yearlyPlans]
 
     function findMonthlyPlanByWeeklyPlanId(weeklyPlanId) {
       if (!weeklyPlanId) return null
@@ -519,43 +719,15 @@ async function selectTaskForReport(order) {
       editingReport.value.processProgress = editingReport.value.prevProgress
     }
 
-    const tmrwStr = tomorrowDate.value
-    availableTomorrowPlans.value = allPlans.filter(
-      (p) =>
-        getTradeNameFromRecord(p) === myProcess.value &&
-        tmrwStr >= toDateString(p.startDate) &&
-        tmrwStr <= toDateString(p.endDate),
-    )
+    await loadApprovedScheduleChanges()
+    applyApprovedScheduleTarget()
+    applyMonthlyScheduleWeights(weeklyPlans)
   } catch (e) {
-    console.error('명일 주간계획 로드 실패', e)
+    console.error('공사일보 계획 정보 로드 실패', e)
   }
 
+  applyApprovedScheduleTarget()
   showEditor.value = true
-}
-
-// feat : 명일 주간계획 선택 시 내용 자동 바인딩
-function onTomorrowPlanSelect() {
-  const planId = editingReport.value.tomorrowWorkPlanId
-  const targetPlan = availableTomorrowPlans.value.find((p) => p.idx === planId || p.id === planId)
-
-  if (targetPlan) {
-    editingReport.value.tomorrowLocation = targetPlan.location || editingReport.value.location
-    editingReport.value.tomorrowPlan = targetPlan.name || ''
-    if (targetPlan.note) editingReport.value.tomorrowPlan += `\n\n${targetPlan.note}`
-
-    editingReport.value.tomorrowWorkers = targetPlan.requiredCount || 0
-
-    if (targetPlan.equipmentDisplay) {
-      const tEqList = []
-      targetPlan.equipmentDisplay.split(',').forEach((item) => {
-        const match = item.trim().match(/(.+)\s+(\d+)대/)
-        if (match) tEqList.push(`${match[1].trim()} ${match[2]}대`)
-      })
-      editingReport.value.tomorrowEquipmentList = [...new Set(tEqList)]
-    } else {
-      editingReport.value.tomorrowEquipmentList = []
-    }
-  }
 }
 
 // feat : 기존 작성된 보고서 수정
@@ -570,13 +742,14 @@ async function openEditor(report) {
     monthlyWorkPlanId: report.monthlyWorkPlanId || null,
     monthlyWorkPlanName: report.monthlyWorkPlanName || '',
     todayMonthlyOrderCount: report.todayMonthlyOrderCount || 1,
-    tomorrowWorkPlanId: null,
-    tomorrowLocation: report.location || '',
-    tomorrowWorkers: 0,
-    tomorrowEquipmentList: [],
-    tomorrowEquipmentInput: { name: '', count: 1 },
-    tomorrowPlan: report.tomorrowPlan || '',
-    tomorrowSafety: '',
+    approvedDailyTargetPct: report.approvedDailyTargetPct || null,
+    normalDailyTargetPct: report.normalDailyTargetPct || null,
+    dailyTargetSource: report.dailyTargetSource || 'duration',
+    scheduleWeightPct: report.scheduleWeightPct || null,
+    normalScheduleWeightPct: report.normalScheduleWeightPct || null,
+    remainingScheduleWeightPct: report.remainingScheduleWeightPct || null,
+    monthlyScheduleCount: report.monthlyScheduleCount || 0,
+    scheduleWeightSource: report.scheduleWeightSource || 'duration',
     photos: (report.photos || []).map((p) => ({ ...p })),
     files: (report.files || []).map((f) => ({ ...f })),
   }
@@ -633,24 +806,20 @@ async function openEditor(report) {
       }
     }
 
-    const tmrwStr = tomorrowDate.value
-    availableTomorrowPlans.value = allPlans.filter(
-      (p) =>
-        getTradeNameFromRecord(p) === myProcess.value &&
-        tmrwStr >= toDateString(p.startDate) &&
-        tmrwStr <= toDateString(p.endDate),
-    )
+    await loadApprovedScheduleChanges()
+    applyApprovedScheduleTarget()
+    applyMonthlyScheduleWeights(weeklyPlans)
   } catch (e) {
     console.error(e)
   }
 
+  applyApprovedScheduleTarget()
   showEditor.value = true
 }
 
 function closeEditor() {
   showEditor.value = false
   editingReport.value = null
-  modalTab.value = 'today'
 }
 
 // feat : 월간 세부계획 기간 비례 금일 증가분(%) 자동 계산 로직
@@ -666,22 +835,53 @@ const calcInfo = computed(() => {
   // 1. 월간 세부계획 기간 (예: 15일)
   const duration = Math.max(1, Math.round((end - start) / 86400000) + 1)
 
-  // 2. 하루 목표 진척률 (예: 100% / 15일 = 6.67%)
-  const dailyAllocation = 100 / duration
+  // 2. 하루 목표 진척률
+  // 승인된 일정 변경이 있으면 변경안의 목표 진척률을 우선 사용합니다.
+  const normalDailyAllocation = 100 / duration
+  const approvedTargetPct = toNumberOrNull(r.approvedDailyTargetPct)
+  const scheduleWeightPct = toNumberOrNull(r.scheduleWeightPct)
+  const hasScheduleWeight = scheduleWeightPct !== null && scheduleWeightPct > 0
+  const hasApprovedTarget =
+    r.scheduleWeightSource === 'schedule_change' || (approvedTargetPct !== null && approvedTargetPct > 0)
+  const effectiveApprovedTargetPct = approvedTargetPct ?? normalDailyAllocation
+  const dailyAllocation = hasScheduleWeight
+    ? scheduleWeightPct
+    : hasApprovedTarget
+      ? effectiveApprovedTargetPct
+      : normalDailyAllocation
 
   // 3. 금일 발급된 같은 월간 세부계획의 작업 지시서 개수
-  const tasksTodayCount = Math.max(1, r.todayMonthlyOrderCount || availableTodayOrders.value.length)
+  const tasksTodayCount = hasScheduleWeight || hasApprovedTarget
+    ? 1
+    : Math.max(1, r.todayMonthlyOrderCount || availableTodayOrders.value.length)
 
   // 4. 세부 작업 1개당 배분된 가중치
-  const weightPerTask = dailyAllocation / tasksTodayCount
+  const rawWeightPerTask =
+    hasScheduleWeight || hasApprovedTarget ? dailyAllocation : dailyAllocation / tasksTodayCount
 
-  // 5. 사용자가 당긴 해당 세부 작업 완료율에 가중치를 곱함
+  // 5. 남은 하위 일정 가중치까지 고려해 전체 월간 세부계획 진척률이 100%를 넘지 않게 닫습니다.
+  const remainingWeightPct = toNumberOrNull(r.remainingScheduleWeightPct)
+  const closeableWeight =
+    remainingWeightPct !== null
+      ? Math.max(0, 100 - Number(r.prevProgress || 0) - remainingWeightPct)
+      : rawWeightPerTask
+  const weightPerTask = Math.max(0, Math.min(rawWeightPerTask, closeableWeight))
+
+  // 6. 사용자가 입력한 해당 세부 작업 완료율에 가중치를 곱함
   const increment = ((r.progress || 0) / 100) * weightPerTask
 
   return {
     duration,
+    isScheduleChangeTarget: hasApprovedTarget,
+    isMonthlyScheduleWeight: hasScheduleWeight,
     dailyAllocation: parseFloat(dailyAllocation.toFixed(2)),
+    normalDailyAllocation: parseFloat(normalDailyAllocation.toFixed(2)),
+    approvedDailyTargetPct:
+      hasApprovedTarget && approvedTargetPct !== null ? parseFloat(approvedTargetPct.toFixed(2)) : null,
     tasksTodayCount,
+    rawWeightPerTask: parseFloat(rawWeightPerTask.toFixed(2)),
+    remainingScheduleWeightPct:
+      remainingWeightPct !== null ? parseFloat(remainingWeightPct.toFixed(2)) : null,
     weightPerTask: parseFloat(weightPerTask.toFixed(2)),
     increment: parseFloat(increment.toFixed(2)),
   }
@@ -694,6 +894,9 @@ watch(
     editingReport.value?.endDate,
     editingReport.value?.prevProgress,
     editingReport.value?.todayMonthlyOrderCount,
+    editingReport.value?.approvedDailyTargetPct,
+    editingReport.value?.scheduleWeightPct,
+    editingReport.value?.remainingScheduleWeightPct,
   ],
   () => {
     const r = editingReport.value
@@ -717,17 +920,6 @@ function addEquipment() {
 }
 function removeEquipment(idx) {
   editingReport.value.equipmentList.splice(idx, 1)
-}
-
-function addTomorrowEquipment() {
-  const v = (editingReport.value.tomorrowEquipmentInput.name || '').trim()
-  if (!v) return
-  const count = Math.max(1, editingReport.value.tomorrowEquipmentInput.count || 1)
-  editingReport.value.tomorrowEquipmentList.push(v + ' ' + count + '대')
-  editingReport.value.tomorrowEquipmentInput = { name: '', count: 1 }
-}
-function removeTomorrowEquipment(idx) {
-  editingReport.value.tomorrowEquipmentList.splice(idx, 1)
 }
 
 // feat : 복구된 사진 및 첨부파일 업로드 로직
@@ -813,20 +1005,10 @@ async function submitReport() {
     progressIncrementPct: calcInfo.value?.increment ?? 0,
     monthlyProgressPct: parseFloat(r.processProgress || 0),
     actualWorkerCount: r.workers || 0,
+    location: r.location,
     issue: r.notes || '특이사항 없음',
     reportDate: r.date,
     todayWork: r.todayWork,
-
-    // 명일 일정 덮어쓰기용 데이터
-    tomorrowWorkPlanId: r.tomorrowWorkPlanId,
-    tomorrowPlan: r.tomorrowPlan + (r.tomorrowSafety ? `\n\n[안전사항]\n${r.tomorrowSafety}` : ''),
-    tomorrowWorkerCount: r.tomorrowWorkers || 0,
-    tomorrowEquipments: r.tomorrowEquipmentList.map((eqStr) => {
-      const match = eqStr.match(/(.+)\s+(\d+)대/)
-      return match
-        ? { type: match[1].trim(), count: parseInt(match[2], 10) }
-        : { type: '기타', count: 1 }
-    }),
   }
 
   try {
@@ -834,7 +1016,7 @@ async function submitReport() {
     r.submittedAt = new Date().toISOString().slice(0, 16).replace('T', ' ')
     persistEditing('제출 완료')
     closeEditor()
-    alert('🎉 공사일보 제출 및 내일 주간계획 업데이트가 완료되었습니다!')
+    alert('공사일보 제출이 완료되었습니다.')
     loadReportsForDate(selectedDate.value)
   } catch (error) {
     console.error(error)
@@ -845,7 +1027,6 @@ async function submitReport() {
 function persistEditing(newStatus) {
   const r = editingReport.value
   delete r.equipmentInput
-  delete r.tomorrowEquipmentInput
   r.status = newStatus
 
   const idx = reports.value.findIndex((x) => x.id === r.id)
@@ -1053,17 +1234,6 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
         금일 공사일보
       </button>
       <button
-        class="border-b-2 px-4 py-2 text-xs font-bold transition"
-        :class="
-          activeTab === 'tomorrow'
-            ? 'border-flare-500 text-flare-700'
-            : 'border-transparent text-forena-500 hover:text-forena-700'
-        "
-        @click="switchTab('tomorrow')"
-      >
-        명일 작업 예정
-      </button>
-      <button
         v-if="currentRole === ROLES.MANAGER"
         class="inline-flex items-center gap-1.5 border-b-2 px-4 py-2 text-xs font-bold transition"
         :class="
@@ -1188,30 +1358,6 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
         </div>
       </div>
 
-      <div v-else-if="activeTab === 'tomorrow'" class="space-y-3 mt-2">
-        <p class="text-xs text-forena-500">
-          <span class="font-bold tabular-nums text-forena-700">{{ fmtKor(tomorrowDate) }}</span>
-          기준 공종별 작업 예정 내용입니다.
-        </p>
-        <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
-          <div
-            v-for="r in todayReports"
-            :key="'tomorrow_' + r.id"
-            class="rounded-xl border border-forena-100 bg-white p-4"
-          >
-            <div class="flex items-center gap-1.5">
-              <span
-                class="rounded-md bg-forena-50 px-1.5 py-0.5 text-[10px] font-bold text-forena-700"
-                >{{ r.process }} 공종</span
-              >
-            </div>
-            <p class="mt-2 text-[10px] font-bold uppercase tracking-wide text-forena-400">
-              명일 작업 예정
-            </p>
-            <p class="mt-1 text-xs leading-relaxed text-forena-800">{{ r.tomorrowPlan || '—' }}</p>
-          </div>
-        </div>
-      </div>
     </div>
 
     <transition
@@ -1313,35 +1459,8 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
             </button>
           </div>
 
-          <div
-            class="flex shrink-0 items-center gap-1 border-b border-forena-100 bg-forena-50/30 px-6"
-          >
-            <button
-              class="border-b-2 px-3 py-2.5 text-xs font-bold transition"
-              :class="
-                modalTab === 'today'
-                  ? 'border-flare-500 text-flare-700'
-                  : 'border-transparent text-forena-500 hover:text-forena-700'
-              "
-              @click="modalTab = 'today'"
-            >
-              금일 공사 내용
-            </button>
-            <button
-              class="border-b-2 px-3 py-2.5 text-xs font-bold transition"
-              :class="
-                modalTab === 'tomorrow'
-                  ? 'border-flare-500 text-flare-700'
-                  : 'border-transparent text-forena-500 hover:text-forena-700'
-              "
-              @click="modalTab = 'tomorrow'"
-            >
-              명일 작업 예정
-            </button>
-          </div>
-
           <div class="min-h-0 flex-1 overflow-y-auto px-6 py-4">
-            <div v-if="modalTab === 'today'" class="space-y-4">
+            <div class="space-y-4">
               <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
                 <div class="sm:col-span-3">
                   <label
@@ -1522,7 +1641,17 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
                 <p v-if="calcInfo" class="mt-1 text-[10px] text-forena-400">
                   금일 증가분:
                   <span class="font-semibold text-forena-700">{{ calcInfo.increment }}%</span> (기간
-                  {{ calcInfo.duration }}일 · 일일 배분율 {{ calcInfo.dailyAllocation }}%)
+                  {{ calcInfo.duration }}일 ·
+                  <template v-if="calcInfo.isScheduleChangeTarget">
+                    승인 변경 목표 {{ calcInfo.dailyAllocation }}%
+                    <span class="text-forena-300">
+                      / 기본 {{ calcInfo.normalDailyAllocation }}%
+                    </span>
+                  </template>
+                  <template v-else-if="calcInfo.isMonthlyScheduleWeight">
+                    세부일정 가중치 {{ calcInfo.dailyAllocation }}%
+                  </template>
+                  <template v-else>일일 배분율 {{ calcInfo.dailyAllocation }}%</template>)
                 </p>
               </div>
 
@@ -1530,7 +1659,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
                 <div class="mb-2 flex items-center justify-between">
                   <label class="text-[10px] font-bold uppercase tracking-wide text-flare-600">
                     월간 세부계획 진척률
-                    <span class="font-normal text-flare-400">(공기 비례 자동 계산)</span>
+                    <span class="font-normal text-flare-400">(하위 일정 기준 자동 계산)</span>
                   </label>
                   <span class="text-sm font-bold tabular-nums text-flare-700"
                     >{{ editingReport.processProgress }}%</span
@@ -1543,7 +1672,25 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
                   ></div>
                 </div>
                 <p v-if="calcInfo" class="mt-1.5 text-[10px] text-forena-500">
-                  <span class="block mb-0.5 text-forena-600">
+                  <span
+                    v-if="calcInfo.isScheduleChangeTarget"
+                    class="block mb-0.5 text-forena-600"
+                  >
+                    <span class="font-bold">산식:</span> 승인 변경 하루 목표
+                    <span class="font-bold">{{ calcInfo.dailyAllocation }}%</span> × 금일 완료율
+                    <span class="font-bold">{{ editingReport.progress }}%</span> = 금일 증가
+                    <span class="font-bold">{{ calcInfo.increment }}%</span>
+                  </span>
+                  <span
+                    v-else-if="calcInfo.isMonthlyScheduleWeight"
+                    class="block mb-0.5 text-forena-600"
+                  >
+                    <span class="font-bold">산식:</span> 세부일정 가중치
+                    <span class="font-bold">{{ calcInfo.dailyAllocation }}%</span> × 금일 완료율
+                    <span class="font-bold">{{ editingReport.progress }}%</span> = 금일 증가
+                    <span class="font-bold">{{ calcInfo.increment }}%</span>
+                  </span>
+                  <span v-else class="block mb-0.5 text-forena-600">
                     <span class="font-bold">산식:</span> 하루 목표
                     <span class="font-bold">{{ calcInfo.dailyAllocation }}%</span> ÷ 금일 세부작업
                     <span class="font-bold">{{ calcInfo.tasksTodayCount }}건</span> = 건당 최대
@@ -1661,153 +1808,6 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
               </div>
             </div>
 
-            <div v-else-if="modalTab === 'tomorrow'" class="space-y-4 mt-2">
-              <div class="rounded-xl border border-flare-200 bg-flare-50/40 p-4 mb-4">
-                <label class="mb-1.5 block text-xs font-bold text-flare-800"
-                  ><Sparkles class="inline h-3.5 w-3.5 text-flare-600" /> 대상 주간계획 선택</label
-                >
-                <select
-                  v-model="editingReport.tomorrowWorkPlanId"
-                  @change="onTomorrowPlanSelect"
-                  class="w-full rounded-md border border-forena-200 bg-white px-3 py-2 text-sm font-semibold text-forena-800 outline-none focus:border-flare-400"
-                >
-                  <option :value="null">-- 내일 진행할 주간계획 일정을 선택하세요 --</option>
-                  <option
-                    v-for="plan in availableTomorrowPlans"
-                    :key="plan.idx || plan.id"
-                    :value="plan.idx || plan.id"
-                  >
-                    [{{ plan.location }}] {{ plan.name }}
-                  </option>
-                </select>
-                <p class="mt-2 text-[11px] text-forena-600">
-                  위에서 내일 일정을 선택하면 기존 데이터가 불려오며, 수정한 내용은 원본 주간계획에
-                  덮어쓰기 됩니다.
-                </p>
-              </div>
-
-              <div
-                v-if="editingReport.tomorrowWorkPlanId"
-                class="grid grid-cols-1 gap-3 sm:grid-cols-2"
-              >
-                <div class="sm:col-span-2">
-                  <label
-                    class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
-                    ><MapPin class="mr-0.5 inline h-3 w-3" />작업 위치</label
-                  >
-                  <input
-                    v-model="editingReport.tomorrowLocation"
-                    class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs outline-none focus:border-flare-400"
-                  />
-                </div>
-
-                <div>
-                  <label
-                    class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
-                    ><Clock class="mr-0.5 inline h-3 w-3" />작업 시간</label
-                  >
-                  <input
-                    value="07:00 ~ 17:00"
-                    disabled
-                    class="w-full rounded-md border border-forena-200 bg-slate-50 px-2.5 py-1.5 text-xs tabular-nums text-slate-500 outline-none"
-                  />
-                </div>
-
-                <div>
-                  <label
-                    class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
-                    ><Users class="mr-0.5 inline h-3 w-3" />필요 인원</label
-                  >
-                  <input
-                    type="number"
-                    min="0"
-                    v-model.number="editingReport.tomorrowWorkers"
-                    class="w-full rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs tabular-nums outline-none focus:border-flare-400"
-                  />
-                </div>
-
-                <div class="sm:col-span-2">
-                  <label
-                    class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
-                    ><Wrench class="mr-0.5 inline h-3 w-3" />필요 장비</label
-                  >
-                  <div class="flex gap-2">
-                    <select
-                      v-model="editingReport.tomorrowEquipmentInput.name"
-                      class="flex-1 rounded-lg border border-slate-200 px-3 py-2 text-sm"
-                    >
-                      <option value="">장비 선택</option>
-                      <optgroup
-                        v-for="(items, category) in equipmentList"
-                        :key="category"
-                        :label="category"
-                      >
-                        <option
-                          v-for="equipment in items"
-                          :key="category + '_tom_' + equipment"
-                          :value="equipment"
-                        >
-                          {{ equipment }}
-                        </option>
-                      </optgroup>
-                    </select>
-                    <input
-                      type="number"
-                      min="1"
-                      v-model.number="editingReport.tomorrowEquipmentInput.count"
-                      class="w-16 rounded-lg border border-slate-200 px-2 py-2 text-sm text-center tabular-nums"
-                    />
-                    <button
-                      @click="addTomorrowEquipment"
-                      class="inline-flex items-center gap-1 rounded-md border border-flare-200 bg-flare-50 px-2.5 py-1 text-xs font-bold text-flare-700 hover:bg-flare-100"
-                    >
-                      <Plus class="h-3 w-3" />추가
-                    </button>
-                  </div>
-                  <div
-                    v-if="editingReport.tomorrowEquipmentList.length"
-                    class="mt-2 flex flex-wrap gap-1.5"
-                  >
-                    <span
-                      v-for="(eq, i) in editingReport.tomorrowEquipmentList"
-                      :key="i"
-                      class="inline-flex items-center gap-1 rounded-md bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 ring-1 ring-emerald-200"
-                      >{{ eq
-                      }}<button
-                        @click="removeTomorrowEquipment(i)"
-                        class="text-slate-400 hover:text-rose-600"
-                      >
-                        <X class="h-3 w-3" /></button
-                    ></span>
-                  </div>
-                </div>
-
-                <div class="sm:col-span-2">
-                  <label
-                    class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
-                    >작업 상세 내역 <span class="text-rose-500">*</span></label
-                  >
-                  <textarea
-                    v-model="editingReport.tomorrowPlan"
-                    rows="5"
-                    class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"
-                  ></textarea>
-                </div>
-
-                <div class="sm:col-span-2">
-                  <label
-                    class="mb-1 block text-[10px] font-bold uppercase tracking-wide text-forena-500"
-                    >안전 유의사항</label
-                  >
-                  <textarea
-                    v-model="editingReport.tomorrowSafety"
-                    rows="3"
-                    placeholder="추락/낙하/화재 등 위험요인 사전 점검"
-                    class="w-full resize-none rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs leading-relaxed outline-none focus:border-flare-400"
-                  ></textarea>
-                </div>
-              </div>
-            </div>
           </div>
 
           <div
@@ -1961,21 +1961,13 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
               </div>
             </div>
 
-            <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div class="mt-4 grid grid-cols-1 gap-3">
               <div class="rounded-xl border border-forena-100 p-3.5">
                 <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">
                   금일 작업 완료
                 </p>
                 <p class="mt-1 text-xs leading-relaxed text-forena-800">
                   {{ viewingReport.todayWork }}
-                </p>
-              </div>
-              <div class="rounded-xl border border-forena-100 p-3.5">
-                <p class="text-[10px] font-bold uppercase tracking-wide text-forena-400">
-                  명일 작업 예정
-                </p>
-                <p class="mt-1 text-xs leading-relaxed text-forena-800">
-                  {{ viewingReport.tomorrowPlan }}
                 </p>
               </div>
             </div>

--- a/src/views/schedule/WorkInstructionView.vue
+++ b/src/views/schedule/WorkInstructionView.vue
@@ -498,6 +498,76 @@ function cloneOrder(o) {
   }
 }
 
+const DEFAULT_WORK_TIME = '07:00 ~ 17:00'
+const DEFAULT_SAFETY_TEXT =
+  '추락/낙하/화재 등 위험요인 사전 점검 및 안전조치 철저. (지시서 및 일일 TBM 준수)'
+
+const WORK_TIME_SECTION_LABELS = ['작업시간', '작업 시간', '?묒뾽?쒓컙']
+const SAFETY_SECTION_LABELS = ['안전사항', '안전 사항', '안전 유의사항', '?덉쟾?ы빆']
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function sectionPattern(labels) {
+  return labels.map(escapeRegExp).join('|')
+}
+
+function parseInstructionContent(content = '') {
+  const text = String(content || '').replace(/\r\n/g, '\n').trim()
+  const workTimePattern = sectionPattern(WORK_TIME_SECTION_LABELS)
+  const safetyPattern = sectionPattern(SAFETY_SECTION_LABELS)
+  const workTimeMatch = text.match(
+    new RegExp(
+      `\\[\\s*(?:${workTimePattern})\\s*\\]\\s*([\\s\\S]*?)(?=\\n\\s*\\[\\s*(?:${safetyPattern})\\s*\\]|$)`,
+    ),
+  )
+  const safetyMatch = text.match(
+    new RegExp(`\\[\\s*(?:${safetyPattern})\\s*\\]\\s*([\\s\\S]*)$`),
+  )
+  const metaIndexes = [workTimeMatch?.index, safetyMatch?.index].filter(
+    (index) => Number.isInteger(index) && index >= 0,
+  )
+  const workDetail = metaIndexes.length ? text.slice(0, Math.min(...metaIndexes)).trim() : text
+
+  return {
+    workDetail,
+    workTime: workTimeMatch?.[1]?.trim() || '',
+    safety: safetyMatch?.[1]?.trim() || '',
+  }
+}
+
+function buildInstructionFields(order) {
+  const parsed = parseInstructionContent(order.workDetail)
+  const workDetail = parsed.workDetail || String(order.workDetail || '').trim()
+  const safety = String(order.safety || parsed.safety || DEFAULT_SAFETY_TEXT).trim()
+
+  return {
+    instructionContent: workDetail,
+    workDetail,
+    workTime: order.workTime,
+    safetyContent: safety,
+  }
+}
+
+function resolveWorkPlanWorkTime(plan) {
+  if (plan?.workTime) return plan.workTime
+
+  const note = String(plan?.note || '')
+  const timeRange = '(\\d{1,2}:\\d{2})\\s*[~～]\\s*(\\d{1,2}:\\d{2})'
+  const label = '(?:작업\\s*시간|작업시간)'
+  const changed = note.match(new RegExp(`${label}\\s*:?\\s*${timeRange}\\s*(?:->|→)\\s*${timeRange}`))
+  if (changed) return `${changed[3]} ~ ${changed[4]}`
+
+  const bracket = note.match(new RegExp(`\\[${label}\\]\\s*${timeRange}`))
+  if (bracket) return `${bracket[1]} ~ ${bracket[2]}`
+
+  const labeled = note.match(new RegExp(`${label}\\s*:?\\s*${timeRange}`))
+  if (labeled) return `${labeled[1]} ~ ${labeled[2]}`
+
+  return DEFAULT_WORK_TIME
+}
+
 // 🔥 수정된 작업 리스트 먼저 불러오는 함수
 async function openCreate() {
   const targetDate = filterDate.value
@@ -547,14 +617,16 @@ async function selectTaskForOrder(task) {
   editing.value.workPlanId = task.idx || task.id
   editing.value.location = task.location || ''
   editing.value.workers = task.requiredCount || 0
-  editing.value.workTime = '07:00 ~ 17:00'
+  editing.value.workTime = resolveWorkPlanWorkTime(task)
   editing.value.workDetail = task.name + (task.note ? '\n' + task.note : '')
+  editing.value.safety = DEFAULT_SAFETY_TEXT
 
   draftAutoFilled.value = {
     location: true,
     workTime: true,
     workers: true,
     workDetail: true,
+    safety: true,
     equipment: true,
   }
 
@@ -716,6 +788,8 @@ async function submitOrder() {
     equipments: equipmentList,
   }
 
+  Object.assign(requestPayload, buildInstructionFields(r))
+
   try {
     if (isNew.value) {
       requestPayload.statusCode = 'OPEN'
@@ -802,6 +876,7 @@ async function updateOrderStatus(newStatus, statusCodeStr) {
           }
         }),
       }
+      Object.assign(requestPayload, buildInstructionFields(order))
       await updateWorkOrder(rawId, requestPayload)
     }
 
@@ -893,6 +968,11 @@ async function fetchWorkOrders() {
         time = subParts[0] ? subParts[0].trim() : ''
         if (subParts.length > 1) safetyText = subParts[1].trim()
       }
+      const parsedContent = parseInstructionContent(dto.instructionContent || '')
+      detail = dto.workDetail || parsedContent.workDetail
+      time = dto.workTime || parsedContent.workTime || time
+      safetyText = dto.safetyContent || parsedContent.safety || safetyText
+
       return {
         id: `WO-${dto.idx}`,
         date: dto.dueDate,

--- a/src/views/schedule/WorkPlanView.vue
+++ b/src/views/schedule/WorkPlanView.vue
@@ -56,13 +56,17 @@ async function loadMainTrades() {
   try {
     const response = await fetchTradeProcessList({ projectId: selectedProjectId.value })
     if (response && Array.isArray(response)) {
-      const uniqueTrades = [...new Set(
-        response
-          .filter(item => !item.isMilestone && !item.milestone)
-          .map(item => item.trade || item.tradeName)
-      )].filter(Boolean)
-      
-      mainTrades.value = uniqueTrades.length ? uniqueTrades : ['공통/가설', '토공사', '지정/기초', '골조공사', '건축마감', '기계/설비']
+      const uniqueTrades = [
+        ...new Set(
+          response
+            .filter((item) => !item.isMilestone && !item.milestone)
+            .map((item) => item.trade || item.tradeName),
+        ),
+      ].filter(Boolean)
+
+      mainTrades.value = uniqueTrades.length
+        ? uniqueTrades
+        : ['공통/가설', '토공사', '지정/기초', '골조공사', '건축마감', '기계/설비']
       if (mainTrades.value.length > 0) uploadModalTrade.value = mainTrades.value[0]
     }
   } catch (error) {
@@ -80,9 +84,6 @@ function triggerFileUpload() {
     monthlyInputRef.value?.click()
   }
 }
-
-
-
 
 // 연장 정보 헬퍼 (planStore 기반)
 function extOf(p) {
@@ -172,6 +173,49 @@ function displayWeekStart(plan) {
   if (plan?.weekStart) return plan.weekStart
   if (!plan?.start) return '-'
   return formatDateLocal(getWeekStart(new Date(plan.start)))
+}
+
+function monthlyPlanFor(plan) {
+  const parentId = plan?.parentWorkPlanId
+  if (parentId) {
+    const byId = monthlyPlans.value.find((p) => String(p.id) === String(parentId))
+    if (byId) return byId
+  }
+
+  const parentName = String(plan?.parentWorkPlanName || '').trim()
+  if (parentName) {
+    const byName = monthlyPlans.value.find((p) => String(p.name || '').trim() === parentName)
+    if (byName) return byName
+  }
+
+  return null
+}
+
+function displayMonthlyPlanName(plan) {
+  return monthlyPlanFor(plan)?.name || plan?.parentWorkPlanName || '-'
+}
+
+function displayMonthlyPlanPeriod(plan) {
+  const monthlyPlan = monthlyPlanFor(plan)
+  if (!monthlyPlan?.start && !monthlyPlan?.end) return ''
+  return `${monthlyPlan.start || '-'} ~ ${monthlyPlan.end || '-'}`
+}
+
+function displayWorkTime(plan) {
+  if (plan?.workTime) return plan.workTime
+
+  const note = String(plan?.note || '')
+  const timeRange = '(\\d{1,2}:\\d{2})\\s*[~～]\\s*(\\d{1,2}:\\d{2})'
+  const changed = note.match(new RegExp(`작업시간\\s*:?\\s*${timeRange}\\s*(?:->|→)\\s*${timeRange}`))
+  if (changed) return `${changed[3]} ~ ${changed[4]}`
+
+  const bracket = note.match(new RegExp(`\\[작업시간\\]\\s*${timeRange}`))
+  if (bracket) return `${bracket[1]} ~ ${bracket[2]}`
+
+  const labeled = note.match(new RegExp(`작업시간\\s*:?\\s*${timeRange}`))
+  if (labeled) return `${labeled[1]} ~ ${labeled[2]}`
+
+  return '-'
 }
 
 const HOLIDAY_DATES = new Set([
@@ -754,13 +798,13 @@ async function submitWeeklyForm() {
     await submitWeeklyWorkPlan(payload)
 
     showWeeklyForm.value = false
-    alert(`${w.partner} (${w.manager}) 주간 계획서 ${w.items.length}건이 제출되었습니다.`)
+    alert(`${w.partner} (${w.manager}) 세부 계획서 ${w.items.length}건이 제출되었습니다.`)
 
     // 제출 후 목록 재조회 (서버에 저장된 새 plan들이 반영됨)
     await loadPlans()
   } catch (err) {
-    console.error('주간 계획서 제출 실패:', err)
-    alert(err.message || '주간 계획서 제출에 실패했습니다.')
+    console.error('세부 계획서 제출 실패:', err)
+    alert(err.message || '세부 계획서 제출에 실패했습니다.')
   }
 }
 function cancelWeeklyForm() {
@@ -804,12 +848,11 @@ watch([filterTrade, filterStatus], () => {
 })
 
 onMounted(() => {
-  loadPlans()         // 기존 계획 데이터 로드
-  loadMainTrades()    // 신규 추가: 업로드용 공종 리스트 로드
+  loadPlans() // 기존 계획 데이터 로드
+  loadMainTrades() // 신규 추가: 업로드용 공종 리스트 로드
 })
 
-onBeforeUnmount(() => {
-})
+onBeforeUnmount(() => {})
 
 function importAi() {
   alert('AI로 작업계획을 불러옵니다. (데모)')
@@ -1499,26 +1542,38 @@ function onClickWorkPlan(wp) {
           </button>
         </div>
 
-              <button
-                type="button"
-                class="inline-flex items-center gap-1.5 rounded-lg border border-forena-200 bg-white px-3 py-1.5 text-xs font-semibold text-forena-700 hover:bg-forena-50"
-               @click="isUploadPopupOpen = true"
-              >
-                <Upload class="h-3.5 w-3.5 text-forena-400" /> 계획서 업로드
-              </button>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-lg border border-forena-200 bg-white px-3 py-1.5 text-xs font-semibold text-forena-700 hover:bg-forena-50"
+          @click="isUploadPopupOpen = true"
+        >
+          <Upload class="h-3.5 w-3.5 text-forena-400" /> 계획서 업로드
+        </button>
 
-              <input ref="yearlyInputRef" type="file" class="sr-only" @change="(e) => onFileChange(e, '연간')" accept=".pdf,.xlsx,.xls,.csv,.png,.jpg,.jpeg" />
-              <input ref="monthlyInputRef" type="file" class="sr-only" @change="(e) => onFileChange(e, '월간')" accept=".pdf,.xlsx,.xls,.csv,.png,.jpg,.jpeg" />
+        <input
+          ref="yearlyInputRef"
+          type="file"
+          class="sr-only"
+          @change="(e) => onFileChange(e, '연간')"
+          accept=".pdf,.xlsx,.xls,.csv,.png,.jpg,.jpeg"
+        />
+        <input
+          ref="monthlyInputRef"
+          type="file"
+          class="sr-only"
+          @change="(e) => onFileChange(e, '월간')"
+          accept=".pdf,.xlsx,.xls,.csv,.png,.jpg,.jpeg"
+        />
 
-                     <button
-                       type="button"
-                       class="inline-flex items-center gap-1.5 rounded-lg border border-forena-200 bg-white px-3 py-1.5 text-xs font-semibold text-forena-700 hover:bg-forena-50"
-                        @click="openWeeklyForm"
-                      >
-                       <ClipboardList class="h-3.5 w-3.5 text-forena-400" /> 주간계획서 작성
-                      </button>
-                   </div>
-                 </div>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-lg border border-forena-200 bg-white px-3 py-1.5 text-xs font-semibold text-forena-700 hover:bg-forena-50"
+          @click="openWeeklyForm"
+        >
+          <ClipboardList class="h-3.5 w-3.5 text-forena-400" /> 세부계획서 작성
+        </button>
+      </div>
+    </div>
 
     <!-- 필터 바 -->
     <div
@@ -1687,7 +1742,7 @@ function onClickWorkPlan(wp) {
                 <div class="mb-3 flex items-center gap-1.5">
                   <ClipboardList class="h-3.5 w-3.5 text-flare-600" />
                   <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
-                    >주간 계획서 정보</span
+                    >세부 계획서 정보</span
                   >
                 </div>
                 <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
@@ -1710,9 +1765,15 @@ function onClickWorkPlan(wp) {
                     </p>
                   </div>
                   <div class="rounded-lg bg-forena-50/60 px-3 py-2">
-                    <p class="text-[10px] font-bold text-forena-400">주 시작일</p>
-                    <p class="mt-1 text-sm font-semibold tabular-nums text-forena-900">
-                      {{ displayWeekStart(selectedPlan) }}
+                    <p class="text-[10px] font-bold text-forena-400">월간 세부계획</p>
+                    <p class="mt-1 text-sm font-semibold text-forena-900">
+                      {{ displayMonthlyPlanName(selectedPlan) }}
+                    </p>
+                    <p
+                      v-if="displayMonthlyPlanPeriod(selectedPlan)"
+                      class="mt-0.5 text-[11px] tabular-nums text-forena-500"
+                    >
+                      {{ displayMonthlyPlanPeriod(selectedPlan) }}
                     </p>
                   </div>
                 </div>
@@ -1746,7 +1807,7 @@ function onClickWorkPlan(wp) {
               </div>
 
               <!-- 🌟 여기서부터 교체 시작 🌟 -->
-              <div class="grid gap-3 sm:grid-cols-3">
+              <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
                 <!-- 1. 작업 위치 -->
                 <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
                   <div class="flex items-center gap-1.5 mb-2">
@@ -1760,7 +1821,20 @@ function onClickWorkPlan(wp) {
                   </p>
                 </div>
 
-                <!-- 2. 필요 인원 -->
+                <!-- 2. 작업 시간 -->
+                <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
+                  <div class="flex items-center gap-1.5 mb-2">
+                    <CalendarRange class="h-3.5 w-3.5 text-flare-600" />
+                    <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400"
+                      >작업 시간</span
+                    >
+                  </div>
+                  <p class="text-sm font-semibold tabular-nums text-forena-900">
+                    {{ displayWorkTime(selectedPlan) }}
+                  </p>
+                </div>
+
+                <!-- 3. 필요 인원 -->
                 <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
                   <div class="flex items-center gap-1.5 mb-2">
                     <Users class="h-3.5 w-3.5 text-flare-600" />
@@ -1795,7 +1869,7 @@ function onClickWorkPlan(wp) {
                   </div>
                 </div>
 
-                <!-- 필요 장비 섹션 -->
+                <!-- 4. 필요 장비 -->
                 <div class="rounded-xl border border-forena-100 bg-forena-50/40 p-3.5">
                   <div class="flex items-center gap-1.5 mb-2">
                     <Wrench class="h-3.5 w-3.5 text-flare-600" />
@@ -2149,11 +2223,11 @@ function onClickWorkPlan(wp) {
               <div class="relative flex-1 w-full min-w-[1000px]" :style="{ width: yearChartWidth }">
                 <div class="sticky top-0 z-[5] flex h-10 border-b border-forena-200 bg-white">
                   <div
-                     v-for="m in yearMeta.months"
-                      :key="m.month"
-                      class="flex-1 flex items-center justify-center border-r border-forena-100 text-[11px] font-semibold tabular-nums"
+                    v-for="m in yearMeta.months"
+                    :key="m.month"
+                    class="flex-1 flex items-center justify-center border-r border-forena-100 text-[11px] font-semibold tabular-nums"
                     :class="m.isCurrent ? 'bg-flare-50 text-flare-700' : 'text-forena-500'"
-                    >
+                  >
                     {{ m.label }}
                   </div>
                 </div>
@@ -2771,7 +2845,7 @@ function onClickWorkPlan(wp) {
                 <ClipboardList class="h-5 w-5 text-flare-600" />
               </div>
               <div>
-                <p class="text-base font-bold text-forena-900">주간 계획서 작성</p>
+                <p class="text-base font-bold text-forena-900">세부 계획서 작성</p>
                 <p class="mt-0.5 text-xs text-forena-500">
                   협력사 담당자가 직접 작성합니다. 일자별
                   <span class="font-bold text-flare-700">공정명·작업구역·인력·장비</span>는 모두
@@ -3086,66 +3160,80 @@ function onClickWorkPlan(wp) {
       </div>
     </transition>
     <transition
-  enter-active-class="transition duration-200 ease-out"
-  enter-from-class="opacity-0 scale-95"
-  enter-to-class="opacity-100 scale-100"
-  leave-active-class="transition duration-150 ease-in"
-  leave-from-class="opacity-100 scale-100"
-  leave-to-class="opacity-0 scale-95"
->
-  <div v-if="isUploadPopupOpen" class="fixed inset-0 z-[100] flex items-center justify-center p-4">
-    <div class="absolute inset-0 bg-slate-900/40 backdrop-blur-sm" @click="isUploadPopupOpen = false"></div>
-    
-    <div class="relative w-full max-w-md overflow-hidden rounded-xl bg-white shadow-2xl">
-      <div class="flex items-center justify-between border-b border-slate-100 px-5 py-4">
-        <h3 class="text-sm font-bold text-slate-800">계획서 업로드 설정</h3>
-        <button @click="isUploadPopupOpen = false" class="rounded-lg p-1 hover:bg-slate-100">
-          <X class="h-4 w-4 text-slate-400" />
-        </button>
-      </div>
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0 scale-95"
+      enter-to-class="opacity-100 scale-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100 scale-100"
+      leave-to-class="opacity-0 scale-95"
+    >
+      <div
+        v-if="isUploadPopupOpen"
+        class="fixed inset-0 z-[100] flex items-center justify-center p-4"
+      >
+        <div
+          class="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"
+          @click="isUploadPopupOpen = false"
+        ></div>
 
-      <div class="space-y-5 p-6">
-        <div class="space-y-2">
-          <label class="text-[11px] font-bold text-slate-500">공종 선택</label>
-          <select 
-            v-model="uploadModalTrade"
-            class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm focus:border-flare-500 focus:outline-none"
-          >
-            <option v-for="trade in mainTrades" :key="trade" :value="trade">{{ trade }}</option>
-          </select>
-        </div>
-
-        <div class="space-y-2">
-          <label class="text-[11px] font-bold text-slate-500">계획 종류</label>
-          <div class="grid grid-cols-2 gap-2">
-            <button 
-              @click="uploadModalType = '연간'"
-              :class="uploadModalType === '연간' ? 'border-flare-500 bg-flare-50 text-flare-700' : 'border-slate-200 bg-white text-slate-600'"
-              class="rounded-lg border py-3 text-xs font-semibold transition-all"
-            >
-              연간 계획서
+        <div class="relative w-full max-w-md overflow-hidden rounded-xl bg-white shadow-2xl">
+          <div class="flex items-center justify-between border-b border-slate-100 px-5 py-4">
+            <h3 class="text-sm font-bold text-slate-800">계획서 업로드 설정</h3>
+            <button @click="isUploadPopupOpen = false" class="rounded-lg p-1 hover:bg-slate-100">
+              <X class="h-4 w-4 text-slate-400" />
             </button>
-            <button 
-              @click="uploadModalType = '월간'"
-              :class="uploadModalType === '월간' ? 'border-flare-500 bg-flare-50 text-flare-700' : 'border-slate-200 bg-white text-slate-600'"
-              class="rounded-lg border py-3 text-xs font-semibold transition-all"
+          </div>
+
+          <div class="space-y-5 p-6">
+            <div class="space-y-2">
+              <label class="text-[11px] font-bold text-slate-500">공종 선택</label>
+              <select
+                v-model="uploadModalTrade"
+                class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 text-sm focus:border-flare-500 focus:outline-none"
+              >
+                <option v-for="trade in mainTrades" :key="trade" :value="trade">{{ trade }}</option>
+              </select>
+            </div>
+
+            <div class="space-y-2">
+              <label class="text-[11px] font-bold text-slate-500">계획 종류</label>
+              <div class="grid grid-cols-2 gap-2">
+                <button
+                  @click="uploadModalType = '연간'"
+                  :class="
+                    uploadModalType === '연간'
+                      ? 'border-flare-500 bg-flare-50 text-flare-700'
+                      : 'border-slate-200 bg-white text-slate-600'
+                  "
+                  class="rounded-lg border py-3 text-xs font-semibold transition-all"
+                >
+                  연간 계획서
+                </button>
+                <button
+                  @click="uploadModalType = '월간'"
+                  :class="
+                    uploadModalType === '월간'
+                      ? 'border-flare-500 bg-flare-50 text-flare-700'
+                      : 'border-slate-200 bg-white text-slate-600'
+                  "
+                  class="rounded-lg border py-3 text-xs font-semibold transition-all"
+                >
+                  월간 계획서
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div class="bg-slate-50 px-6 py-4">
+            <button
+              @click="triggerFileUpload"
+              class="flex w-full items-center justify-center gap-2 rounded-lg bg-slate-900 py-3 text-xs font-bold text-white hover:bg-slate-800"
             >
-              월간 계획서
+              계획서 업로드 <ArrowRight class="h-3.5 w-3.5" />
             </button>
           </div>
         </div>
       </div>
-
-      <div class="bg-slate-50 px-6 py-4">
-        <button 
-          @click="triggerFileUpload"
-          class="flex w-full items-center justify-center gap-2 rounded-lg bg-slate-900 py-3 text-xs font-bold text-white hover:bg-slate-800"
-        >
-          다음 단계로 <ArrowRight class="h-3.5 w-3.5" />
-        </button>
-      </div>
-    </div>
-  </div>
-</transition>
+    </transition>
   </div>
 </template>


### PR DESCRIPTION
## Summary

공정 분석 화면에서 공사일보 기반 지연 분석과 AI 추천 수정안을 활용해 세부일정 변경 요청을 생성할 수 있도록 개선했습니다.

## Changes

- 공사일보에 기록된 월간 세부계획 실제 진척률을 기준으로 지연 위험 작업을 판단하도록 변경
- 당일 공사일보가 아직 제출되지 않은 작업은 지연 위험 판단에서 제외
- 마일스톤 공정이 공종별 진척률에 노출되지 않도록 필터링
- AI 추천 수정안 생성 및 조회 API 연동
- AI 추천안 요청 모달에서 변경 대상 세부일정을 건별로 표시
- 변경 요청/승인/일정 반영 흐름에 필요한 상세 변경 데이터를 포함
- 승인된 변경안이 공정계획/작업지시서/공사일보 진척률 계산에 반영되도록 개선
- 작업지시서 상세에서 작업시간과 안전 유의사항을 분리 표시
- 공사일보 작성 화면에서 명일 작업 예정 영역 제거
- 공사일보 위치 저장 및 재조회 시 위치 누락 문제 수정
- 사이드바에서 AI 분석 이력 메뉴 제거
