### PR TITLE
[Feat] 현장 및 공종별 권한 스코프 적용

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -6,7 +6,7 @@ const ADMIN_ACCOUNTS = '/admin/accounts'
 /**
  * 로그인 — AuthController POST /auth/login
  * @param {{ loginId: string, password: string }} body
- * @returns {Promise<{ accessToken: string, userIdx: number, name: string, role: string, siteCode?: string|null, trade?: string|null }>}
+ * @returns {Promise<{ accessToken: string, userIdx: number, projectId?: number|null, name: string, role: string, siteCode?: string|null, trade?: string|null }>}
  */
 export async function postAuthLogin(body) {
   return await api.post(`${AUTH}/login`, body)

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -38,6 +38,12 @@ api.interceptors.response.use(
     return body
   },
   (error) => {
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      return Promise.reject(
+        new Error('권한이 없습니다. 데모 계정이 아니라 실제 서버 계정으로 다시 로그인해 주세요.'),
+      )
+    }
+
     const message =
       error.response?.data?.message ||
       error.response?.data?.error ||

--- a/src/api/project.js
+++ b/src/api/project.js
@@ -6,6 +6,14 @@ export async function getProjectList() {
 }
 
 /**
+ * @param {number|string} projectId
+ * @returns {Promise<{ idx: number, name: string, location?: string, startDate?: string|null, endDate?: string|null, period?: string }>}
+ */
+export async function getProject(projectId) {
+  return await api.get(`/project/${projectId}`)
+}
+
+/**
  * @param {{ name: string, location?: string, startDate?: string|null, endDate?: string|null }} body
  */
 export async function createProject(body) {

--- a/src/api/tradeProcess.js
+++ b/src/api/tradeProcess.js
@@ -37,9 +37,10 @@ export const fetchTradeProcessList = async (params = {}) => {
  * @param {string}        [params.tradeName]  공종 필터 (선택)
  * @returns {Promise<Array>}
  */
-export const listTradeProcessesRaw = async ({ projectId, tradeName } = {}) => {
+export const listTradeProcessesRaw = async ({ projectId, tradeName, includeAllTrades = false } = {}) => {
   const params = { projectId }
   if (tradeName) params.tradeName = tradeName
+  if (includeAllTrades) params.includeAllTrades = true
   const dtos = await api.get(PATH, { params })
   return Array.isArray(dtos) ? dtos : []
 }

--- a/src/api/workplan.js
+++ b/src/api/workplan.js
@@ -178,7 +178,9 @@ export const deleteWorkPlan = (planId) => {
   return api.delete(`${PATH}/${planId}`)
 }
 
-export const fetchWorkPlansByProject = async (projectId) => {
-  const dtos = await api.get(`${PATH}/project/${projectId}`)
+export const fetchWorkPlansByProject = async (projectId, options = {}) => {
+  const params = {}
+  if (options.includeAllTrades) params.includeAllTrades = true
+  const dtos = await api.get(`${PATH}/project/${projectId}`, { params })
   return Array.isArray(dtos) ? dtos.map(toPlan) : []
 }

--- a/src/components/schedule/workPlan/WorkPlanYearlyGantt.vue
+++ b/src/components/schedule/workPlan/WorkPlanYearlyGantt.vue
@@ -53,7 +53,7 @@ defineEmits(['toggle-group', 'select-baseline', 'select-work-plan'])
       {{ yearMeta.year }}년에 표시할 기준 공정이 없습니다.
     </div>
 
-    <div v-else class="flex min-w-max">
+    <div v-else class="flex min-w-full">
       <div
         class="sticky left-0 z-10 shrink-0 border-r border-forena-200 bg-white"
         :style="{ width: NAME_COL_W + 'px' }"
@@ -113,14 +113,14 @@ defineEmits(['toggle-group', 'select-baseline', 'select-work-plan'])
         </template>
       </div>
 
-      <div class="relative shrink-0" :style="{ width: chartWidth }">
+      <div class="relative min-w-0 flex-1" :style="{ minWidth: chartWidth, width: '100%' }">
         <div class="sticky top-0 z-[5] flex h-10 border-b border-forena-200 bg-white">
           <div
             v-for="month in yearMeta.months"
             :key="month.month"
-            class="flex shrink-0 items-center justify-center border-r border-forena-100 text-[11px] font-semibold tabular-nums"
+            class="flex min-w-0 flex-1 items-center justify-center border-r border-forena-100 text-[11px] font-semibold tabular-nums"
             :class="month.isCurrent ? 'bg-flare-50 text-flare-700' : 'text-forena-500'"
-            :style="{ width: GANTT_MONTH_W + 'px' }"
+            :style="{ minWidth: GANTT_MONTH_W + 'px' }"
           >
             {{ month.label }}
           </div>
@@ -142,8 +142,8 @@ defineEmits(['toggle-group', 'select-baseline', 'select-work-plan'])
                 <div
                   v-for="month in yearMeta.months"
                   :key="month.month"
-                  class="shrink-0 border-r border-forena-50"
-                  :style="{ width: GANTT_MONTH_W + 'px' }"
+                  class="min-w-0 flex-1 border-r border-forena-50"
+                  :style="{ minWidth: GANTT_MONTH_W + 'px' }"
                 ></div>
 
                 <div

--- a/src/composables/schedule/workPlan/useWorkPlanGantt.js
+++ b/src/composables/schedule/workPlan/useWorkPlanGantt.js
@@ -9,6 +9,7 @@ import {
   isWorkPlanGroupInProgress,
   workPlanStatus,
 } from '@/utils/schedule/workPlan.js'
+import { tradeMatches } from '@/utils/authScope'
 
 export function useWorkPlanGantt({
   baselinePlans,
@@ -96,7 +97,7 @@ export function useWorkPlanGantt({
     let r = [...baselinePlans.value, ...monthlyPlans.value]
 
     if (filterTrade.value) {
-      r = r.filter((p) => p.trade === filterTrade.value)
+      r = r.filter((p) => tradeMatches(p.trade, filterTrade.value))
     }
 
     if (filterStatus.value) {
@@ -110,7 +111,7 @@ export function useWorkPlanGantt({
     let r = [...baselinePlans.value, ...annualPlans.value]
 
     if (filterTrade.value) {
-      r = r.filter((p) => p.trade === filterTrade.value)
+      r = r.filter((p) => tradeMatches(p.trade, filterTrade.value))
     }
 
     if (filterStatus.value) {
@@ -184,16 +185,17 @@ export function useWorkPlanGantt({
     const e = endStr > lastDate ? lastDate : endStr
     const sm = Number(s.slice(5, 7))
     const em = Number(e.slice(5, 7))
-    const span = Math.max(1, em - sm + 1)
     const startDay = Number(s.slice(8, 10))
     const endDay = Number(e.slice(8, 10))
     const startMonthDays = new Date(year, sm, 0).getDate()
     const endMonthDays = new Date(year, em, 0).getDate()
-    const leftOffset = ((startDay - 1) / startMonthDays) * GANTT_MONTH_W
-    const rightTrim = ((endMonthDays - endDay) / endMonthDays) * GANTT_MONTH_W
+    const leftMonthOffset = (startDay - 1) / startMonthDays
+    const rightMonthOffset = endDay / endMonthDays
+    const leftPct = (((sm - 1) + leftMonthOffset) / 12) * 100
+    const rightPct = (((em - 1) + rightMonthOffset) / 12) * 100
     return {
-      left: `${(sm - 1) * GANTT_MONTH_W + leftOffset + 4}px`,
-      width: `${span * GANTT_MONTH_W - leftOffset - rightTrim - 8}px`,
+      left: `${leftPct}%`,
+      width: `${Math.max(0.2, rightPct - leftPct)}%`,
     }
   }
 
@@ -243,18 +245,17 @@ export function useWorkPlanGantt({
     const fillLeft = parseFloat(fill.left)
     const fillWidth = parseFloat(fill.width)
     const width = Math.max(0, Math.min(fullWidth, fillLeft + fillWidth - fullLeft))
+    const pct = fullWidth > 0 ? (width / fullWidth) * 100 : 0
 
-    return { width: `${width}px` }
+    return { width: `${Math.max(0, Math.min(100, pct))}%` }
   }
 
   function progressDotStyle(p, styleFn) {
     const widthValue = progressBarStyle(p, styleFn).width
-    const width = widthValue.endsWith('%')
-      ? (parseFloat(widthValue) / 100) * parseFloat(styleFn(p.start, p.end)?.width || 0)
-      : parseFloat(widthValue)
+    const width = parseFloat(widthValue)
 
     if (!Number.isFinite(width) || width <= 0) return { display: 'none' }
-    return { left: `${Math.max(0, width - 4)}px` }
+    return { left: `calc(${Math.max(0, Math.min(100, width))}% - 4px)` }
   }
 
   // 오늘 라인

--- a/src/composables/schedule/workPlan/useWorkPlanWeeklyCalendar.js
+++ b/src/composables/schedule/workPlan/useWorkPlanWeeklyCalendar.js
@@ -5,6 +5,7 @@ import {
   isHolidayDate,
   workPlanStatus,
 } from '@/utils/schedule/workPlan.js'
+import { tradeMatches } from '@/utils/authScope'
 
 export function useWorkPlanWeeklyCalendar({
   weeklyPlans,
@@ -18,8 +19,8 @@ export function useWorkPlanWeeklyCalendar({
   const filtered = computed(() => {
     let result = viewMode.value === 'weekly' ? weeklyPlans.value : monthlyPlans.value
 
-    if (viewMode.value !== 'weekly' && filterTrade.value) {
-      result = result.filter((plan) => plan.trade === filterTrade.value)
+    if (filterTrade.value) {
+      result = result.filter((plan) => tradeMatches(plan.trade, filterTrade.value))
     }
 
     if (filterStatus.value) {

--- a/src/composables/useCurrentProject.js
+++ b/src/composables/useCurrentProject.js
@@ -1,5 +1,6 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
+import { useAuthStore } from '@/stores/authStore'
 
 export const DEFAULT_PROJECT_ID = 1
 
@@ -27,9 +28,14 @@ export function resolveProjectId(routeLike) {
 
 export function useCurrentProject(fallbackProjectId = DEFAULT_PROJECT_ID) {
   const route = useRoute()
+  const auth = useAuthStore()
 
   const currentProjectId = computed(
-    () => resolveProjectId(route) ?? toProjectId(fallbackProjectId) ?? DEFAULT_PROJECT_ID,
+    () =>
+      resolveProjectId(route) ??
+      toProjectId(auth.projectId) ??
+      toProjectId(fallbackProjectId) ??
+      DEFAULT_PROJECT_ID,
   )
 
   return {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -162,11 +162,15 @@ const router = createRouter({
 
 router.beforeEach((to) => {
   const auth = useAuthStore()
+  const uploadRoute = () => {
+    const query = auth.projectId ? { ...to.query, projectId: String(auth.projectId) } : to.query
+    return { path: '/site/upload', query }
+  }
 
   if (to.path === '/login') {
     if (auth.isAuthenticated) {
       if (auth.stayOnLogin) return true
-      return { path: '/site/dashboard' }
+      return auth.initialUploadRequired ? uploadRoute() : { path: '/site/dashboard' }
     }
     return true
   }
@@ -175,8 +179,19 @@ router.beforeEach((to) => {
     return { path: '/login' }
   }
 
+  if (
+    auth.initialUploadRequired &&
+    to.path !== '/site/upload' &&
+    to.path !== '/account/password' &&
+    pathAllowedForRole(auth.userRole, '/site/upload')
+  ) {
+    return uploadRoute()
+  }
+
   if (!pathAllowedForRole(auth.userRole, to.path)) {
-    return { path: '/site/dashboard' }
+    return auth.initialUploadRequired && pathAllowedForRole(auth.userRole, '/site/upload')
+      ? uploadRoute()
+      : { path: '/site/dashboard' }
   }
   return true
 })

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -20,6 +20,25 @@ const LEGACY_AUTH_STORAGE_KEYS = ['dndnAuth']
 
 /** 세션 형식 버전 bump 시 기존 자동 로그인 무력화 */
 const AUTH_STORAGE_KEY = 'dndnAuth_v2'
+const INITIAL_UPLOAD_DONE_PREFIX = 'dndnInitialUploadDone_v1'
+
+function normalizeProjectId(value) {
+  const n = Number(value)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+function initialUploadDoneKey({ loginId, projectId, siteCode }) {
+  const scope = projectId != null ? `project:${projectId}` : `site:${siteCode || 'unknown'}`
+  return `${INITIAL_UPLOAD_DONE_PREFIX}:${scope}:${loginId || 'unknown'}`
+}
+
+function hasInitialUploadDone(snapshot) {
+  return localStorage.getItem(initialUploadDoneKey(snapshot)) === '1'
+}
+
+function rememberInitialUploadDone(snapshot) {
+  localStorage.setItem(initialUploadDoneKey(snapshot), '1')
+}
 
 /**
  * 과거 형식 또는 신뢰할 수 없는 스냅샷 제거 + JWT 무효화
@@ -104,10 +123,16 @@ export function pathAllowedForRole(userRole, fullPath) {
   ) {
     if (path.startsWith('/hr/accounts') || path.startsWith('/hr/sites')) return false
     if (path.startsWith('/system/')) return false
+    if (path === '/site/upload') return isInitialUploadRole(role)
     return path.startsWith('/site/') || path.startsWith('/hr/')
   }
 
   return false
+}
+
+export function isInitialUploadRole(userRole) {
+  const role = normalizeUserRole(userRole)
+  return role === USER_ROLE.SITE_DIRECTOR || role === USER_ROLE.SITE_MANAGER
 }
 
 export function userRoleLabel(userRole) {
@@ -139,6 +164,15 @@ export const useAuthStore = defineStore('auth', () => {
   /** @type {import('vue').Ref<number|string|null>} */
   const userIdx = ref(saved?.userIdx ?? null)
 
+  /** @type {import('vue').Ref<number|null>} */
+  const projectId = ref(normalizeProjectId(saved?.projectId))
+
+  /** @type {import('vue').Ref<string>} */
+  const siteCode = ref(saved?.siteCode || '')
+
+  /** @type {import('vue').Ref<string>} */
+  const trade = ref(saved?.trade || '')
+
   const isAuthenticated = ref(Boolean(saved?.isAuthenticated))
 
   /** 본사·대시보드만 보기(구 viewer 데모) */
@@ -150,6 +184,9 @@ export const useAuthStore = defineStore('auth', () => {
   const roleLabel = computed(() => userRoleLabel(userRole.value))
 
   const isAdminRole = computed(() => userRole.value === USER_ROLE.ADMIN)
+  const initialUploadRequired = computed(
+    () => isUpload.value && isInitialUploadRole(userRole.value),
+  )
 
   function persistAuth() {
     const sessionKind = localStorage.getItem('accessToken') ? 'server' : 'demo'
@@ -159,6 +196,9 @@ export const useAuthStore = defineStore('auth', () => {
       loginId: loginId.value,
       userName: userName.value,
       userIdx: userIdx.value,
+      projectId: projectId.value,
+      siteCode: siteCode.value,
+      trade: trade.value,
       isAuthenticated: isAuthenticated.value,
       stayOnLogin: stayOnLogin.value,
       isUpload: isUpload.value,
@@ -188,13 +228,41 @@ export const useAuthStore = defineStore('auth', () => {
     if (lid) loginId.value = lid
     userName.value = loginRes?.name ?? ''
     userIdx.value = loginRes?.userIdx ?? null
+    projectId.value = normalizeProjectId(loginRes?.projectId)
+    siteCode.value = String(loginRes?.siteCode ?? '').trim()
+    trade.value = String(loginRes?.trade ?? '').trim()
     stayOnLogin.value = Boolean(options.stayOnLogin)
     if (Object.prototype.hasOwnProperty.call(options, 'isUpload')) {
       isUpload.value = Boolean(options.isUpload)
+    } else if (Object.prototype.hasOwnProperty.call(loginRes ?? {}, 'needsInitialUpload')) {
+      isUpload.value = Boolean(loginRes.needsInitialUpload)
+    } else if (Object.prototype.hasOwnProperty.call(loginRes ?? {}, 'isUpload')) {
+      isUpload.value = Boolean(loginRes.isUpload)
     } else {
-      isUpload.value = true
+      isUpload.value =
+        isInitialUploadRole(userRole.value) &&
+        !hasInitialUploadDone({
+          loginId: loginId.value,
+          projectId: projectId.value,
+          siteCode: siteCode.value,
+        })
     }
     isAuthenticated.value = true
+    persistAuth()
+  }
+
+  function markInitialUploadComplete() {
+    isUpload.value = false
+    rememberInitialUploadDone({
+      loginId: loginId.value,
+      projectId: projectId.value,
+      siteCode: siteCode.value,
+    })
+    persistAuth()
+  }
+
+  function setProjectId(value) {
+    projectId.value = normalizeProjectId(value)
     persistAuth()
   }
 
@@ -211,6 +279,9 @@ export const useAuthStore = defineStore('auth', () => {
       loginId.value = 'admin'
       userName.value = '데모 관리자'
       userIdx.value = null
+      projectId.value = null
+      siteCode.value = ''
+      trade.value = ''
       stayOnLogin.value = false
       isUpload.value = false
       isAuthenticated.value = true
@@ -223,6 +294,9 @@ export const useAuthStore = defineStore('auth', () => {
       loginId.value = 'viewer'
       userName.value = '데모 본사'
       userIdx.value = null
+      projectId.value = null
+      siteCode.value = ''
+      trade.value = ''
       stayOnLogin.value = true
       isUpload.value = false
       isAuthenticated.value = true
@@ -240,6 +314,9 @@ export const useAuthStore = defineStore('auth', () => {
     loginId.value = ''
     userName.value = ''
     userIdx.value = null
+    projectId.value = null
+    siteCode.value = ''
+    trade.value = ''
     localStorage.removeItem('accessToken')
     localStorage.removeItem(AUTH_STORAGE_KEY)
   }
@@ -249,12 +326,18 @@ export const useAuthStore = defineStore('auth', () => {
     loginId,
     userName,
     userIdx,
+    projectId,
+    siteCode,
+    trade,
     roleLabel,
     isAdminRole,
     isAuthenticated,
     stayOnLogin,
     isUpload,
+    initialUploadRequired,
     applyLoginSuccess,
+    markInitialUploadComplete,
+    setProjectId,
     loginDemo,
     logout,
     persistAuth,

--- a/src/utils/authScope.js
+++ b/src/utils/authScope.js
@@ -1,0 +1,60 @@
+import { computed, watch } from 'vue'
+import { USER_ROLE } from '@/stores/authStore'
+
+export const ROLE_VIEW_MODE = {
+  MANAGER: 'site_manager',
+  TRADE: 'process_owner',
+}
+
+export function isSiteManagerRole(role) {
+  return [USER_ROLE.ADMIN, USER_ROLE.SITE_MANAGER, USER_ROLE.SITE_DIRECTOR].includes(role)
+}
+
+export function isTradeScopedRole(role) {
+  return [USER_ROLE.SECTION_LEADER, USER_ROLE.SECTION_SUPERVISOR].includes(role)
+}
+
+export function cleanTrade(value) {
+  return String(value || '').trim()
+}
+
+export function tradeMatches(recordTrade, assignedTrade) {
+  const left = cleanTrade(recordTrade)
+  const right = cleanTrade(assignedTrade)
+  if (!right) return true
+  if (!left) return false
+  return left === right || left.includes(right) || right.includes(left)
+}
+
+export function useAuthScope(auth) {
+  const isManagerScope = computed(() => isSiteManagerRole(auth.userRole))
+  const isTradeScope = computed(() => isTradeScopedRole(auth.userRole))
+  const assignedTrade = computed(() => cleanTrade(auth.trade))
+  const currentRoleMode = computed(() =>
+    isTradeScope.value ? ROLE_VIEW_MODE.TRADE : ROLE_VIEW_MODE.MANAGER,
+  )
+
+  function syncRoleMode(targetRoleRef, targetTradeRef) {
+    targetRoleRef.value = currentRoleMode.value
+    if (isTradeScope.value && assignedTrade.value) {
+      targetTradeRef.value = assignedTrade.value
+    }
+  }
+
+  function watchRoleMode(targetRoleRef, targetTradeRef) {
+    watch(
+      [currentRoleMode, assignedTrade],
+      () => syncRoleMode(targetRoleRef, targetTradeRef),
+      { immediate: true },
+    )
+  }
+
+  return {
+    isManagerScope,
+    isTradeScope,
+    assignedTrade,
+    currentRoleMode,
+    syncRoleMode,
+    watchRoleMode,
+  }
+}

--- a/src/views/document/FirstDocumentUpload.vue
+++ b/src/views/document/FirstDocumentUpload.vue
@@ -1,9 +1,12 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 
 import router from '@/router/index.js'
 import { parseGanttJSON } from '@/utils/ganttParser.js'
 import { useGanttStore } from '@/stores/ganttStore.js'
+import { useAuthStore } from '@/stores/authStore.js'
+import { useCurrentProject } from '@/composables/useCurrentProject.js'
+import { getProject, getProjectList } from '@/api/project.js'
 import { uploadAndExtractSchedule, updateTradeProcess } from '@/api/masterSchedule.js'
 import { buildGanttData, isTaskDirty, taskToReqBody } from '@/utils/scheduleMapper.js'
 import FirstDocumentUploadCards from '@/components/schedule/firstDocumentUpload/FirstDocumentUploadCards.vue'
@@ -39,6 +42,12 @@ const props = defineProps({
 })
 
 const ganttStore = useGanttStore()
+const authStore = useAuthStore()
+const { currentProjectId } = useCurrentProject(props.projectId)
+const resolvedProjectId = ref(null)
+const activeProjectId = computed(
+  () => resolvedProjectId.value ?? authStore.projectId ?? currentProjectId.value,
+)
 
 // =====================================================
 // 상수
@@ -97,12 +106,14 @@ const uploads = ref({
 })
 
 const projectMeta = ref({
-  siteName: '강남 복합개발 1공구',
-  projectName: '강남 복합개발 1공구 신축공사',
-  startDate: '2025-01-01',
-  endDate: '2027-01-31',
-  manager: '박현수',
+  siteName: '',
+  location: '',
+  startDate: '',
+  endDate: '',
+  manager: authStore.userName || '',
 })
+const projectMetaLoading = ref(false)
+const projectMetaError = ref('')
 
 const currentStep = ref(1)
 const analyzeAll = ref(false)
@@ -117,6 +128,94 @@ const ganttPreviewModal = ref(false)
 // =====================================================
 // 헬퍼
 // =====================================================
+function toDateInputValue(value) {
+  return value ? String(value).slice(0, 10) : ''
+}
+
+function parseProjectLabel(name) {
+  const raw = String(name || '').trim()
+  const match = /^\s*\[(?<code>[^\]]+)\]\s*(?<displayName>.+)$/.exec(raw)
+  if (!match?.groups) {
+    return { code: '', displayName: raw }
+  }
+  return {
+    code: match.groups.code.trim(),
+    displayName: match.groups.displayName.trim(),
+  }
+}
+
+function siteCodeMatches(project, siteCode) {
+  const expected = String(siteCode || '').trim().toUpperCase()
+  if (!expected) return false
+  return parseProjectLabel(project?.name).code.toUpperCase() === expected
+}
+
+function applyProjectMeta(project) {
+  const displayName = parseProjectLabel(project?.name).displayName
+  const projectId = Number(project?.idx)
+  if (Number.isFinite(projectId) && projectId > 0) {
+    resolvedProjectId.value = projectId
+    if (!authStore.projectId) authStore.setProjectId(projectId)
+  }
+
+  projectMeta.value = {
+    siteName: displayName,
+    location: String(project?.location || '').trim(),
+    startDate: toDateInputValue(project?.startDate),
+    endDate: toDateInputValue(project?.endDate),
+    manager: authStore.userName || projectMeta.value.manager || '',
+  }
+}
+
+async function resolveProjectForCurrentUser(projectId) {
+  if (!authStore.projectId && authStore.siteCode) {
+    const projects = await getProjectList()
+    const matched = projects.find((project) => siteCodeMatches(project, authStore.siteCode))
+    if (matched) return matched
+  }
+  return await getProject(projectId)
+}
+
+let projectMetaRequestSeq = 0
+
+async function loadProjectMeta(projectId) {
+  if (!projectId) return
+  const seq = ++projectMetaRequestSeq
+  projectMetaLoading.value = true
+  projectMetaError.value = ''
+  try {
+    const project = await resolveProjectForCurrentUser(projectId)
+    if (seq !== projectMetaRequestSeq) return
+    applyProjectMeta(project)
+  } catch (e) {
+    if (seq !== projectMetaRequestSeq) return
+    projectMetaError.value = e?.message || '현장 정보를 불러오지 못했습니다.'
+    if (!projectMeta.value.manager && authStore.userName) {
+      projectMeta.value.manager = authStore.userName
+    }
+  } finally {
+    if (seq === projectMetaRequestSeq) {
+      projectMetaLoading.value = false
+    }
+  }
+}
+
+watch(
+  () => [currentProjectId.value, authStore.projectId, authStore.siteCode],
+  () => loadProjectMeta(activeProjectId.value),
+  { immediate: true },
+)
+
+watch(
+  () => authStore.userName,
+  (name) => {
+    if (name && !projectMeta.value.manager) {
+      projectMeta.value.manager = name
+    }
+  },
+  { immediate: true },
+)
+
 const colorMap = {
   blue: {
     bg: 'bg-sky-50',
@@ -158,6 +257,27 @@ const colorMap = {
 
 const hasAnyUpload = computed(() => Object.values(uploads.value).some((u) => u.fileName))
 const hasMaster = computed(() => !!uploads.value.master.fileName)
+const isAnalyzingAny = computed(() =>
+  Object.values(uploads.value).some((u) => ['uploading', 'analyzing'].includes(u.status)),
+)
+const isProjectMetaComplete = computed(
+  () =>
+    projectMeta.value.siteName.trim() &&
+    projectMeta.value.location.trim() &&
+    projectMeta.value.startDate &&
+    projectMeta.value.endDate &&
+    projectMeta.value.manager.trim(),
+)
+const canStartScheduleGeneration = computed(
+  () => isProjectMetaComplete.value && hasMaster.value && !isAnalyzingAny.value,
+)
+const generationReadyMessage = computed(() => {
+  if (!isProjectMetaComplete.value) return '프로젝트 기본 정보를 먼저 확인해주세요.'
+  if (!hasMaster.value) return '마스터 공정표를 업로드해주세요.'
+  if (isAnalyzingAny.value) return 'AI 분석이 끝난 뒤 공정표를 생성할 수 있습니다.'
+  if (uploads.value.master.status === 'done') return '마스터 공정표 분석 결과로 공정표를 생성할 수 있습니다.'
+  return '버튼을 누르면 등록된 마스터 공정표를 먼저 분석한 뒤 공정표를 생성합니다.'
+})
 
 const allDone = computed(() =>
   Object.values(uploads.value)
@@ -198,6 +318,8 @@ function onFileSelect(typeKey, event) {
   uploads.value[typeKey].fileName = f.name
   uploads.value[typeKey].status = 'idle'
   uploads.value[typeKey].error = ''
+  uploads.value[typeKey].result = null
+  if (typeKey === 'master') resetOptionalAnalysisResultsAfterMasterChange()
   event.target.value = ''
 }
 
@@ -210,6 +332,8 @@ function onDrop(typeKey, event) {
   uploads.value[typeKey].fileName = f.name
   uploads.value[typeKey].status = 'idle'
   uploads.value[typeKey].error = ''
+  uploads.value[typeKey].result = null
+  if (typeKey === 'master') resetOptionalAnalysisResultsAfterMasterChange()
 }
 function onDragOver(event) {
   event.preventDefault()
@@ -227,6 +351,18 @@ function removeFile(typeKey) {
   }
 }
 
+function resetOptionalAnalysisResultsAfterMasterChange() {
+  for (const dt of DOC_TYPES) {
+    if (dt.key === 'master') continue
+    const upload = uploads.value[dt.key]
+    if (!upload.fileName) continue
+    upload.status = 'idle'
+    upload.progress = 0
+    upload.result = null
+    upload.error = ''
+  }
+}
+
 // AI 분석 실행 — 백엔드 업로드 + OpenAI 추출 호출
 async function runAnalysis(typeKey) {
   const u = uploads.value[typeKey]
@@ -240,6 +376,8 @@ async function runAnalysis(typeKey) {
     return
   }
 
+  if (typeKey === 'master') resetOptionalAnalysisResultsAfterMasterChange()
+
   u.status = 'uploading'
   u.progress = 0
   u.error = ''
@@ -247,7 +385,7 @@ async function runAnalysis(typeKey) {
 
   try {
     const tradeProcesses = await uploadAndExtractSchedule({
-      projectId: props.projectId,
+      projectId: activeProjectId.value,
       docType: docType.label, // 한글 라벨 그대로 전달
       file: u.file,
       onUploadProgress: (percent) => {
@@ -356,8 +494,8 @@ function handleReviewClick() {
   // 프로젝트 기본 정보 검사
   if (!projectMeta.value.siteName.trim())
     errors.push({ field: '현장명', msg: '현장명을 입력해주세요.' })
-  if (!projectMeta.value.projectName.trim())
-    errors.push({ field: '공사명', msg: '공사명을 입력해주세요.' })
+  if (!projectMeta.value.location.trim())
+    errors.push({ field: '공사 위치', msg: '공사 위치를 입력해주세요.' })
   if (!projectMeta.value.startDate)
     errors.push({ field: '공사 시작일', msg: '공사 시작일을 선택해주세요.' })
   if (!projectMeta.value.endDate)
@@ -379,6 +517,13 @@ function handleReviewClick() {
   //   다른 3종(마일스톤/공종별/보할)은 본 운영 시 필수로 전환 예정.
   if (!uploads.value.master.fileName)
     errors.push({ field: '마스터 공정표', msg: '마스터 공정표 파일을 업로드해주세요.' })
+  if (uploads.value.master.status === 'error')
+    errors.push({
+      field: '마스터 공정표',
+      msg: uploads.value.master.error || '마스터 공정표 분석에 실패했습니다. 다시 분석해주세요.',
+    })
+  if (['uploading', 'analyzing'].includes(uploads.value.master.status))
+    errors.push({ field: '마스터 공정표', msg: '마스터 공정표 분석이 끝난 뒤 다시 시도해주세요.' })
 
   if (errors.length > 0) {
     validationErrors.value = errors
@@ -399,16 +544,14 @@ function handleReviewClick() {
       )
       if (allComplete) {
         clearInterval(checkDone)
-        rebuildGanttFromResults()
-        ganttPreviewModal.value = true
+        openGanttPreviewFromResults()
       }
     }, 500)
     return
   }
 
   // 이미 분석 완료된 경우 바로 모달 오픈
-  rebuildGanttFromResults()
-  ganttPreviewModal.value = true
+  openGanttPreviewFromResults()
 }
 
 // =====================================================
@@ -439,6 +582,22 @@ function rebuildGanttFromResults() {
   ganttTasks.value = tasks
   ganttMilestones.value = milestones
   ganttProjectInfo.value = projectInfo
+}
+
+function openGanttPreviewFromResults() {
+  rebuildGanttFromResults()
+  if (!ganttTasks.value.length) {
+    validationErrors.value = [
+      {
+        field: 'AI 추출 결과',
+        msg: '마스터 공정표에서 공정 항목을 찾지 못했습니다. 파일 내용을 확인하거나 다시 분석해주세요.',
+      },
+    ]
+    validationModal.value = true
+    return false
+  }
+  ganttPreviewModal.value = true
+  return true
 }
 
 async function confirmAndNavigate() {
@@ -495,7 +654,8 @@ async function confirmAndNavigate() {
   const projectInfoForStore = {
     ...(ganttProjectInfo.value ?? {}),
     siteName: projectMeta.value.siteName,
-    projectName: projectMeta.value.projectName || ganttProjectInfo.value?.projectName || '공정표',
+    projectName: projectMeta.value.siteName || ganttProjectInfo.value?.projectName || '공정표',
+    location: projectMeta.value.location,
     finalApprover: projectMeta.value.manager,
     // 사용자가 입력한 공사 기간이 있으면 우선 사용
     startDate: projectMeta.value.startDate || ganttProjectInfo.value?.startDate,
@@ -507,7 +667,8 @@ async function confirmAndNavigate() {
 
   // 3) 라우팅
   ganttPreviewModal.value = false
-  router.push('/site/schedule')
+  authStore.markInitialUploadComplete()
+  router.push({ path: '/site/schedule', query: { projectId: String(activeProjectId.value) } })
 }
 </script>
 
@@ -572,7 +733,7 @@ async function confirmAndNavigate() {
           <p class="text-sm font-bold text-forena-900 mb-1">공정표 문서 등록 안내</p>
           <div class="text-[11px] leading-relaxed text-forena-600 space-y-1">
             <p>
-              ① <strong>프로젝트 기본 정보</strong>(현장명, 공사명, 공사 기간, 책임자)를 먼저
+              ① <strong>프로젝트 기본 정보</strong>(현장명, 공사 위치, 공사 기간, 책임자)를 먼저
               입력해주세요.
             </p>
             <p>
@@ -601,6 +762,12 @@ async function confirmAndNavigate() {
           <BarChart3 class="h-4 w-4 text-flare-600" />
           <h2 class="text-sm font-bold text-forena-900">프로젝트 기본 정보</h2>
           <span class="ml-1 text-[11px] text-forena-400">필수 항목을 모두 입력해주세요</span>
+          <span v-if="projectMetaLoading" class="ml-auto text-[11px] font-semibold text-forena-500">
+            현장 정보 불러오는 중
+          </span>
+          <span v-else-if="projectMetaError" class="ml-auto text-[11px] font-semibold text-rose-500">
+            {{ projectMetaError }}
+          </span>
         </div>
         <div class="grid gap-3 p-5 pt-4 sm:grid-cols-2 lg:grid-cols-3">
           <!-- 현장명 -->
@@ -612,7 +779,6 @@ async function confirmAndNavigate() {
               v-model="projectMeta.siteName"
               type="text"
               placeholder="예) 강남 복합개발 1공구"
-              value="강남 복합개발 1공구"
               :class="[
                 'mt-1 w-full rounded-lg border px-2.5 py-2 text-xs text-forena-800 outline-none transition',
                 !projectMeta.siteName.trim()
@@ -621,19 +787,18 @@ async function confirmAndNavigate() {
               ]"
             />
           </div>
-          <!-- 공사명 -->
+          <!-- 공사 위치 -->
           <div class="sm:col-span-1 lg:col-span-2">
             <label class="text-[10px] font-bold uppercase text-forena-400">
-              공사명 <span class="text-rose-500">*</span>
+              공사 위치 <span class="text-rose-500">*</span>
             </label>
             <input
-              v-model="projectMeta.projectName"
+              v-model="projectMeta.location"
               type="text"
-              placeholder="예) 강남 복합개발 1공구 신축공사"
-              value="강남 복합개발 1공구 신축공사"
+              placeholder="예) 서울 강남구 삼성동 123"
               :class="[
                 'mt-1 w-full rounded-lg border px-2.5 py-2 text-xs text-forena-800 outline-none transition',
-                !projectMeta.projectName.trim()
+                !projectMeta.location.trim()
                   ? 'border-forena-200 focus:border-flare-400'
                   : 'border-emerald-300 bg-emerald-50/30 focus:border-emerald-400',
               ]"
@@ -647,7 +812,6 @@ async function confirmAndNavigate() {
             <input
               v-model="projectMeta.startDate"
               type="date"
-              value="2025-01-01"
               :class="[
                 'mt-1 w-full rounded-lg border px-2.5 py-2 text-xs text-forena-800 outline-none transition',
                 !projectMeta.startDate
@@ -664,7 +828,6 @@ async function confirmAndNavigate() {
             <input
               v-model="projectMeta.endDate"
               type="date"
-              value="2027-01-31"
               :class="[
                 'mt-1 w-full rounded-lg border px-2.5 py-2 text-xs text-forena-800 outline-none transition',
                 !projectMeta.endDate
@@ -682,7 +845,6 @@ async function confirmAndNavigate() {
               v-model="projectMeta.manager"
               type="text"
               placeholder="예) 박현수"
-              value="박현수"
               :class="[
                 'mt-1 w-full rounded-lg border px-2.5 py-2 text-xs text-forena-800 outline-none transition',
                 !projectMeta.manager.trim()
@@ -698,7 +860,7 @@ async function confirmAndNavigate() {
             <span
               :class="
                 projectMeta.siteName &&
-                projectMeta.projectName &&
+                projectMeta.location &&
                 projectMeta.startDate &&
                 projectMeta.endDate &&
                 projectMeta.manager
@@ -709,7 +871,7 @@ async function confirmAndNavigate() {
               <CheckCircle2
                 v-if="
                   projectMeta.siteName &&
-                  projectMeta.projectName &&
+                  projectMeta.location &&
                   projectMeta.startDate &&
                   projectMeta.endDate &&
                   projectMeta.manager
@@ -718,7 +880,7 @@ async function confirmAndNavigate() {
               />
               {{
                 projectMeta.siteName &&
-                projectMeta.projectName &&
+                projectMeta.location &&
                 projectMeta.startDate &&
                 projectMeta.endDate &&
                 projectMeta.manager
@@ -887,15 +1049,13 @@ async function confirmAndNavigate() {
     >
       <div class="flex flex-wrap items-center justify-between gap-4">
         <div class="text-white">
-          <p class="text-base font-bold">준비가 완료되면 AI 공정표를 생성해보세요</p>
-          <p class="mt-1 text-xs text-forena-300">
-            기본 정보와 3가지 문서가 모두 등록되어야 AI 분석이 시작됩니다. 빠진 항목이 있으면
-            안내해드립니다.
-          </p>
+          <p class="text-base font-bold">마스터 공정표로 AI 공정표를 생성해보세요</p>
+          <p class="mt-1 text-xs text-forena-300">{{ generationReadyMessage }}</p>
         </div>
         <button
+          :disabled="!canStartScheduleGeneration"
           @click="handleReviewClick"
-          class="inline-flex items-center gap-2 rounded-xl bg-white px-6 py-3 text-sm font-bold text-forena-900 shadow-md hover:bg-forena-50 transition"
+          class="inline-flex items-center gap-2 rounded-xl bg-white px-6 py-3 text-sm font-bold text-forena-900 shadow-md transition hover:bg-forena-50 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500 disabled:shadow-none"
         >
           <CalendarRange class="h-4 w-4 text-flare-600" />
           AI 공정표 생성하기

--- a/src/views/schedule/AnalysisView.vue
+++ b/src/views/schedule/AnalysisView.vue
@@ -28,14 +28,23 @@ import RejectRequestModal from '@/components/schedule/analysis/RejectRequestModa
 import TaskDetailModal from '@/components/schedule/analysis/TaskDetailModal.vue'
 import ScheduleChangeTab from '@/components/schedule/analysis/ScheduleChangeTab.vue'
 import { ShieldCheck, UserCog, ClipboardList, BarChart3, Activity, Layers } from 'lucide-vue-next'
+import { useAuthStore } from '@/stores/authStore'
+import { tradeMatches, useAuthScope } from '@/utils/authScope'
 
 // 권한
+const auth = useAuthStore()
+const { isTradeScope, assignedTrade } = useAuthScope(auth)
+const canSwitchAuthority = computed(() => auth.isAdminRole)
 const currentTrade = ref('all')
 
 const isSupervisor = computed(() => currentTrade.value === 'all')
 
 // 대표 공종 단위로 권한 선택
 const tradeAuthorityOptions = computed(() => {
+  if (isTradeScope.value && assignedTrade.value) {
+    return [{ id: `trade:${assignedTrade.value}`, name: assignedTrade.value }]
+  }
+
   const names = new Set()
   processes.value.forEach((p) => {
     const tradeName = inferRepresentativeTradeName(p)
@@ -63,6 +72,17 @@ const selectedTradeId = ref(null)
 const filterProcess = ref('전체')
 const filterStatus = ref('전체')
 const filterRisk = ref('전체')
+
+watch(
+  [isTradeScope, assignedTrade],
+  () => {
+    currentTrade.value = isTradeScope.value && assignedTrade.value ? assignedTrade.value : 'all'
+    selectedTradeId.value = null
+    filterProcess.value = '전체'
+  },
+  { immediate: true },
+)
+
 watch([currentTrade, filterProcess], () => {
   if (processes.value.length > 0) {
     loadDelayRiskTasks()
@@ -117,8 +137,12 @@ const errorMessage = ref('')
 
 async function loadWorkPlanDetails() {
   const [monthlyRes, weeklyRes] = await Promise.all([
-    api.get('/work-plan', { params: { planType: '월간' } }).catch(() => ({ data: [] })),
-    api.get('/work-plan', { params: { planType: '주간' } }).catch(() => ({ data: [] })),
+    api
+      .get('/work-plan', { params: { projectId: currentProjectId.value, planType: '월간' } })
+      .catch(() => ({ data: [] })),
+    api
+      .get('/work-plan', { params: { projectId: currentProjectId.value, planType: '주간' } })
+      .catch(() => ({ data: [] })),
   ])
 
   monthlyWorkPlans.value = normalizeListResponse(monthlyRes)
@@ -222,7 +246,7 @@ async function loadDelayRiskTasks() {
     }),
   )
   delayTasks.value = processName
-    ? mappedTasks.filter((task) => task.process === processName)
+    ? mappedTasks.filter((task) => tradeMatches(task.process, processName))
     : mappedTasks
 
   if (!selectedTaskId.value && delayTasks.value.length > 0) {
@@ -284,7 +308,7 @@ onMounted(() => {
 // 화면 표시용 필터
 function passProcessFilter(name) {
   if (filterProcess.value === '전체') return true
-  return name === filterProcess.value
+  return tradeMatches(name, filterProcess.value)
 }
 function passStatusFilter(status) {
   if (filterStatus.value === '전체') return true
@@ -299,7 +323,7 @@ const visibleProcesses = computed(() => {
   let r = processes.value
   if (!isSupervisor.value) {
     const myName = currentTradeItem.value?.name
-    r = myName ? r.filter((p) => inferRepresentativeTradeName(p) === myName) : []
+    r = myName ? r.filter((p) => tradeMatches(inferRepresentativeTradeName(p), myName)) : []
   } else {
     r = r.filter((p) => passProcessFilter(inferRepresentativeTradeName(p)))
   }
@@ -312,7 +336,7 @@ const visibleTasks = computed(() => {
   let r = delayTasks.value.filter((t) => t.risk !== '낮음')
   if (!isSupervisor.value) {
     const myName = currentTradeItem.value?.name
-    r = myName ? r.filter((t) => t.process === myName) : []
+    r = myName ? r.filter((t) => tradeMatches(t.process, myName)) : []
   } else {
     r = r.filter((t) => passProcessFilter(t.process))
   }
@@ -324,7 +348,7 @@ const visibleRequests = computed(() => {
   let r = changeRequests.value
   if (!isSupervisor.value) {
     const myName = currentTradeItem.value?.name
-    r = myName ? r.filter((req) => req.process === myName) : []
+    r = myName ? r.filter((req) => tradeMatches(req.process, myName)) : []
   } else {
     r = r.filter((req) => passProcessFilter(req.process))
   }
@@ -335,7 +359,7 @@ const visibleHistory = computed(() => {
   let r = changeHistory.value
   if (!isSupervisor.value) {
     const myName = currentTradeItem.value?.name
-    r = myName ? r.filter((h) => h.process === myName) : []
+    r = myName ? r.filter((h) => tradeMatches(h.process, myName)) : []
   } else {
     r = r.filter((h) => passProcessFilter(h.process))
   }
@@ -432,6 +456,7 @@ const riskColor = (r) =>
           <span class="text-[11px] font-bold uppercase tracking-wide text-forena-400">공종</span>
           <select
             v-model="currentTrade"
+            :disabled="!canSwitchAuthority"
             class="cursor-pointer rounded-r-lg bg-forena-800 px-3 py-1.5 text-xs font-bold text-white outline-none transition hover:bg-forena-900"
           >
             <option value="all">현장 총 책임자 (전체)</option>

--- a/src/views/schedule/DailyWorkReportView.vue
+++ b/src/views/schedule/DailyWorkReportView.vue
@@ -20,6 +20,8 @@ import {
   toNumberOrNull,
   todayStr,
 } from '@/utils/schedule/dailyWorkReport.js'
+import { useAuthStore } from '@/stores/authStore'
+import { tradeMatches, useAuthScope } from '@/utils/authScope'
 import {
   CalendarDays,
   ChevronLeft,
@@ -40,9 +42,15 @@ import {
 } from 'lucide-vue-next'
 
 const { currentProjectId } = useCurrentProject()
+const auth = useAuthStore()
+const { isTradeScope, assignedTrade, currentRoleMode } = useAuthScope(auth)
+const canSwitchRole = computed(() => auth.isAdminRole)
 
 const currentRole = ref(ROLES.WORKER)
 const myProcess = ref(ALL_PROCESSES[0])
+const processOptions = computed(() =>
+  isTradeScope.value && assignedTrade.value ? [assignedTrade.value] : ALL_PROCESSES,
+)
 
 const selectedDate = ref(todayStr())
 function prevDay() {
@@ -58,12 +66,25 @@ const isToday = computed(() => selectedDate.value === todayStr())
 
 const activeTab = ref('today')
 
+watch(
+  [currentRoleMode, assignedTrade],
+  () => {
+    currentRole.value = currentRoleMode.value
+    if (isTradeScope.value && assignedTrade.value) {
+      myProcess.value = assignedTrade.value
+    }
+    if (currentRole.value === ROLES.WORKER) activeTab.value = 'today'
+  },
+  { immediate: true },
+)
+
 function switchTab(tab) {
   if (tab === 'consolidated' && currentRole.value !== ROLES.MANAGER) return
   activeTab.value = tab
 }
 
 function switchRole(role) {
+  if (!canSwitchRole.value) return
   currentRole.value = role
   if (role === ROLES.WORKER) activeTab.value = 'today'
 }
@@ -105,12 +126,16 @@ function statusMeta(s) {
 
 const visibleProcesses = computed(() => {
   if (currentRole.value === ROLES.WORKER) return [myProcess.value]
-  return getAllTradeOptions()
+  return processOptions.value.length ? processOptions.value : getAllTradeOptions()
 })
 
 function reportsForDate(dateStr) {
   return reports.value.filter(
-    (r) => r.date === dateStr && visibleProcesses.value.includes(r.process),
+    (r) =>
+      r.date === dateStr &&
+      (currentRole.value === ROLES.WORKER
+        ? tradeMatches(r.process, myProcess.value)
+        : visibleProcesses.value.includes(r.process)),
   )
 }
 
@@ -143,7 +168,7 @@ const availableTodayOrders = ref([])
 
 function canEdit(report) {
   if (currentRole.value === ROLES.MANAGER) return false
-  if (report.process !== myProcess.value) return false
+  if (!tradeMatches(report.process, myProcess.value)) return false
   if (report.status === '승인 완료') return false
   return true
 }
@@ -158,7 +183,7 @@ async function openCreate() {
 
     availableTodayOrders.value = orders.filter(
       (o) =>
-        getTradeNameFromRecord(o) === targetProcess &&
+        tradeMatches(getTradeNameFromRecord(o), targetProcess) &&
         o.dueDate === targetDate &&
         o.statusCode === 'APPROVED',
     )
@@ -220,8 +245,12 @@ async function selectTaskForReport(order) {
 
   try {
     const [weekRes, monthRes] = await Promise.all([
-      api.get('/work-plan', { params: { planType: '주간' } }).catch(() => ({ data: [] })),
-      api.get('/work-plan', { params: { planType: '월간' } }).catch(() => ({ data: [] })),
+      api
+        .get('/work-plan', { params: { projectId: currentProjectId.value, planType: '주간' } })
+        .catch(() => ({ data: [] })),
+      api
+        .get('/work-plan', { params: { projectId: currentProjectId.value, planType: '월간' } })
+        .catch(() => ({ data: [] })),
     ])
 
     const weeklyPlans = Array.isArray(weekRes) ? weekRes : weekRes.data?.data || weekRes.data || []
@@ -319,9 +348,15 @@ async function openEditor(report) {
 
   try {
     const [weekRes, monthRes, yearRes] = await Promise.all([
-      api.get('/work-plan', { params: { planType: '주간' } }).catch(() => ({ data: [] })),
-      api.get('/work-plan', { params: { planType: '월간' } }).catch(() => ({ data: [] })),
-      api.get('/work-plan', { params: { planType: '연간' } }).catch(() => ({ data: [] })),
+      api
+        .get('/work-plan', { params: { projectId: currentProjectId.value, planType: '주간' } })
+        .catch(() => ({ data: [] })),
+      api
+        .get('/work-plan', { params: { projectId: currentProjectId.value, planType: '월간' } })
+        .catch(() => ({ data: [] })),
+      api
+        .get('/work-plan', { params: { projectId: currentProjectId.value, planType: '연간' } })
+        .catch(() => ({ data: [] })),
     ])
 
     const weeklyPlans = Array.isArray(weekRes) ? weekRes : weekRes.data?.data || weekRes.data || []
@@ -567,6 +602,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
                 ? 'bg-forena-800 text-white'
                 : 'text-forena-600 hover:bg-forena-50'
             "
+            :disabled="!canSwitchRole"
             @click="switchRole(ROLES.WORKER)"
           >
             <UserCog class="h-3.5 w-3.5" /> 공종 담당자
@@ -578,6 +614,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
                 ? 'bg-forena-800 text-white'
                 : 'text-forena-600 hover:bg-forena-50'
             "
+            :disabled="!canSwitchRole"
             @click="switchRole(ROLES.MANAGER)"
           >
             <ShieldCheck class="h-3.5 w-3.5" /> 현장 총 책임자
@@ -587,9 +624,10 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
         <select
           v-if="currentRole === ROLES.WORKER"
           v-model="myProcess"
+          :disabled="isTradeScope"
           class="rounded-lg border border-forena-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-forena-700 outline-none focus:border-flare-400"
         >
-          <option v-for="p in ALL_PROCESSES" :key="p" :value="p">{{ p }} 공종</option>
+          <option v-for="p in processOptions" :key="p" :value="p">{{ p }} 공종</option>
         </select>
       </div>
     </div>

--- a/src/views/schedule/ScheduleChartView.vue
+++ b/src/views/schedule/ScheduleChartView.vue
@@ -1039,9 +1039,12 @@ async function loadGanttFromApi() {
   isLoading.value = true
   loadError.value = ''
   try {
-    const rows = await listTradeProcessesRaw({ projectId: currentProjectId.value })
+    const rows = await listTradeProcessesRaw({
+      projectId: currentProjectId.value,
+      includeAllTrades: true,
+    })
 
-    const plans = await fetchWorkPlansByProject(currentProjectId.value)
+    const plans = await fetchWorkPlansByProject(currentProjectId.value, { includeAllTrades: true })
 
     if (!rows.length) {
       // 데이터가 아예 없는 현장 — 일단 빈 상태로 두고 사용자가 등록 페이지에서 업로드하도록

--- a/src/views/schedule/WorkInstructionView.vue
+++ b/src/views/schedule/WorkInstructionView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import api from '@/api/index'
 import WorkInstructionEditorModal from '@/components/schedule/workInstruction/WorkInstructionEditorModal.vue'
 import WorkInstructionTaskSelectorModal from '@/components/schedule/workInstruction/WorkInstructionTaskSelectorModal.vue'
@@ -50,12 +50,25 @@ import {
   toDateString,
   unwrapApiData,
 } from '@/utils/schedule/workInstruction.js'
+import { useAuthStore } from '@/stores/authStore'
+import { tradeMatches, useAuthScope } from '@/utils/authScope'
+import { useCurrentProject } from '@/composables/useCurrentProject.js'
 
 const currentRole = ref(ROLES.WORKER)
 const tradeOptions = ref([...DEFAULT_TRADE_OPTIONS])
 const myProcess = ref(DEFAULT_TRADE_OPTIONS[0])
+const { currentProjectId } = useCurrentProject()
+const auth = useAuthStore()
+const { isTradeScope, assignedTrade, currentRoleMode } = useAuthScope(auth)
+const canSwitchRole = computed(() => auth.isAdminRole)
 
 function ensureSelectedTrade() {
+  if (isTradeScope.value && assignedTrade.value) {
+    myProcess.value = assignedTrade.value
+    filterProcess.value = assignedTrade.value
+    return
+  }
+
   const options = availableTrades.value
   if (!options.length) {
     myProcess.value = ''
@@ -111,6 +124,20 @@ const filterPartner = ref('')
 const filterStatus = ref('')
 const searchKeyword = ref('')
 
+watch(
+  [currentRoleMode, assignedTrade],
+  () => {
+    currentRole.value = currentRoleMode.value
+    if (isTradeScope.value && assignedTrade.value) {
+      myProcess.value = assignedTrade.value
+      filterProcess.value = assignedTrade.value
+    } else if (currentRole.value === ROLES.MANAGER) {
+      filterProcess.value = 'all'
+    }
+  },
+  { immediate: true },
+)
+
 const STATUS_LIST = [
   '작성 전',
   '초안 생성',
@@ -145,6 +172,8 @@ const canReviewViewing = computed(
 const workOrders = ref([])
 
 const availableTrades = computed(() => {
+  if (isTradeScope.value && assignedTrade.value) return [assignedTrade.value]
+
   const merged = new Set(tradeOptions.value)
   workOrders.value.forEach((o) => {
     const tradeName = normalizeTradeName(o.process)
@@ -164,6 +193,7 @@ const visibleTabs = computed(() => {
 })
 
 function onRoleChange(role) {
+  if (!canSwitchRole.value) return
   currentRole.value = role
   if (role === ROLES.WORKER) filterProcess.value = myProcess.value
   else filterProcess.value = 'all'
@@ -175,7 +205,7 @@ function onMyProcessChange() {
 
 const filteredOrders = computed(() => {
   let r = workOrders.value
-  if (currentRole.value === ROLES.WORKER) r = r.filter((o) => o.process === myProcess.value)
+  if (currentRole.value === ROLES.WORKER) r = r.filter((o) => tradeMatches(o.process, myProcess.value))
   else if (filterProcess.value !== 'all') r = r.filter((o) => o.process === filterProcess.value)
   if (filterDate.value) r = r.filter((o) => o.date === filterDate.value)
   if (filterPartner.value) r = r.filter((o) => o.partner.includes(filterPartner.value))
@@ -292,12 +322,14 @@ async function openCreate() {
   const targetProcess = currentRole.value === ROLES.WORKER ? myProcess.value : filterProcess.value
 
   try {
-    const response = await api.get('/work-plan', { params: { planType: '주간' } })
+    const response = await api.get('/work-plan', {
+      params: { projectId: currentProjectId.value, planType: '주간' },
+    })
     const plans = unwrapApiData(response)
 
     availableTasks.value = plans.filter((p) => {
       const planTrade = getTradeNameFromPlan(p)
-      const matchTrade = planTrade === targetProcess
+      const matchTrade = tradeMatches(planTrade, targetProcess)
       const matchDate =
         targetDate >= toDateString(p.startDate) && targetDate <= toDateString(p.endDate)
       return matchTrade && matchDate
@@ -462,7 +494,7 @@ async function submitOrder() {
   })
 
   const requestPayload = {
-    siteIdx: 1,
+    siteIdx: currentProjectId.value,
     partnerCompanyIdx: 1,
     workPlanId: r.workPlanId,
     tradeType: r.process,
@@ -542,7 +574,7 @@ async function updateOrderStatus(newStatus, statusCodeStr) {
       await approveWorkOrder(rawId)
     } else {
       const requestPayload = {
-        siteIdx: 1,
+        siteIdx: currentProjectId.value,
         partnerCompanyIdx: 1,
         tradeType: order.process,
         title: `[${order.process}] ${order.location} 작업지시서`,
@@ -595,7 +627,9 @@ async function fetchTradeOptions() {
   const collected = new Set()
 
   async function collectFromWorkPlans(planType) {
-    const response = await api.get('/work-plan', { params: { planType } })
+    const response = await api.get('/work-plan', {
+      params: { projectId: currentProjectId.value, planType },
+    })
     unwrapApiData(response).forEach((plan) => {
       const tradeName = getTradeNameFromPlan(plan)
       if (tradeName && tradeName !== '기타') collected.add(tradeName)
@@ -611,7 +645,9 @@ async function fetchTradeOptions() {
 
   if (!collected.size) {
     try {
-      const response = await api.get('/trade-process')
+      const response = await api.get('/trade-process', {
+        params: { projectId: currentProjectId.value },
+      })
       unwrapApiData(response).forEach((process) => {
         const tradeName = getTradeNameFromPlan(process)
         if (tradeName && tradeName !== '기타') collected.add(tradeName)
@@ -712,6 +748,7 @@ async function fetchWorkOrders() {
                 ? 'bg-forena-800 text-white'
                 : 'text-forena-600 hover:bg-forena-50'
             "
+            :disabled="!canSwitchRole"
             @click="onRoleChange(ROLES.WORKER)"
           >
             <UserCog class="h-3.5 w-3.5" /> 공정 담당자
@@ -723,6 +760,7 @@ async function fetchWorkOrders() {
                 ? 'bg-forena-800 text-white'
                 : 'text-forena-600 hover:bg-forena-50'
             "
+            :disabled="!canSwitchRole"
             @click="onRoleChange(ROLES.MANAGER)"
           >
             <ShieldCheck class="h-3.5 w-3.5" /> 현장 총 관리자
@@ -732,13 +770,14 @@ async function fetchWorkOrders() {
           v-if="currentRole === ROLES.WORKER"
           v-model="myProcess"
           @change="onMyProcessChange"
-          :disabled="!availableTrades.length"
+          :disabled="isTradeScope || !availableTrades.length"
           class="rounded-lg border border-forena-200 bg-white px-2.5 py-1.5 text-xs font-semibold text-forena-700 outline-none focus:border-flare-400 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400"
         >
           <option v-if="!availableTrades.length" value="">공종 없음</option>
           <option v-for="p in availableTrades" :key="p" :value="p">{{ p }} 공종</option>
         </select>
         <button
+          v-if="currentRole === ROLES.WORKER"
           @click="openCreate"
           class="inline-flex items-center gap-1.5 rounded-lg bg-flare-500 px-3 py-1.5 text-xs font-bold text-white shadow-sm hover:bg-flare-600"
         >

--- a/src/views/schedule/WorkPlanView.vue
+++ b/src/views/schedule/WorkPlanView.vue
@@ -1,5 +1,5 @@
 ﻿<script setup>
-import { ref, onMounted, watch } from 'vue'
+import { computed, ref, onMounted, watch } from 'vue'
 import {
   Upload,
   Users,
@@ -23,6 +23,8 @@ import WorkPlanUploadSettingsModal from '@/components/schedule/workPlan/WorkPlan
 import WorkPlanVerifyModal from '@/components/schedule/workPlan/WorkPlanVerifyModal.vue'
 import WorkPlanWeeklyFormModal from '@/components/schedule/workPlan/WorkPlanWeeklyFormModal.vue'
 import WorkPlanYearlyGantt from '@/components/schedule/workPlan/WorkPlanYearlyGantt.vue'
+import { useAuthStore } from '@/stores/authStore'
+import { tradeMatches, useAuthScope } from '@/utils/authScope'
 import {
   dayTextClass,
   monthlyDayCellClass,
@@ -35,6 +37,9 @@ import {
 } from '@/utils/schedule/workPlan.js'
 
 const { currentProjectId: selectedProjectId } = useCurrentProject()
+const auth = useAuthStore()
+const { isTradeScope, assignedTrade } = useAuthScope(auth)
+const canManageSitePlans = computed(() => !isTradeScope.value)
 
 const weeklyPlans = ref([]) // 주간 작업 계획
 const monthlyPlans = ref([]) // 월간 작업 계획
@@ -45,6 +50,19 @@ const viewMode = ref('weekly')
 const filterTrade = ref('')
 const filterStatus = ref('')
 const selectedPlan = ref(null)
+const tradeFilterOptions = computed(() =>
+  isTradeScope.value && assignedTrade.value ? [assignedTrade.value] : trades,
+)
+
+function scopedByTrade(plans) {
+  if (!isTradeScope.value || !assignedTrade.value) return plans
+  return plans.filter((plan) => tradeMatches(plan.trade, assignedTrade.value))
+}
+
+const scopedWeeklyPlans = computed(() => scopedByTrade(weeklyPlans.value))
+const scopedMonthlyPlans = computed(() => scopedByTrade(monthlyPlans.value))
+const scopedAnnualPlans = computed(() => scopedByTrade(annualPlans.value))
+const scopedBaselinePlans = computed(() => scopedByTrade(baselinePlans.value))
 const {
   uploadFileName,
   uploadCategory,
@@ -96,8 +114,8 @@ const {
   goCurrentWeek,
   plansForDay,
 } = useWorkPlanWeeklyCalendar({
-  weeklyPlans,
-  monthlyPlans,
+  weeklyPlans: scopedWeeklyPlans,
+  monthlyPlans: scopedMonthlyPlans,
   viewMode,
   filterTrade,
   filterStatus,
@@ -121,7 +139,7 @@ const {
   submitWeeklyForm,
   cancelWeeklyForm,
 } = useWeeklyWorkPlanForm({
-  monthlyPlans,
+  monthlyPlans: scopedMonthlyPlans,
   reloadPlans: loadPlans,
 })
 
@@ -134,9 +152,9 @@ async function loadPlans() {
 
     const [baselineRes, weeklyRes, monthlyRes, yearlyRes] = await Promise.all([
       fetchTradeProcessList({ projectId }),
-      fetchWorkPlanList({ planType: '주간' }),
-      fetchWorkPlanList({ planType: '월간' }),
-      fetchWorkPlanList({ planType: '연간' }),
+      fetchWorkPlanList({ projectId, planType: '주간' }),
+      fetchWorkPlanList({ projectId, planType: '월간' }),
+      fetchWorkPlanList({ projectId, planType: '연간' }),
     ])
 
     baselinePlans.value = baselineRes.filter((b) => !baseIsMilestone(b))
@@ -155,6 +173,15 @@ async function loadPlans() {
 watch([filterTrade, filterStatus], () => {
   loadPlans()
 })
+
+watch(
+  [isTradeScope, assignedTrade],
+  () => {
+    filterTrade.value = isTradeScope.value && assignedTrade.value ? assignedTrade.value : ''
+    selectedPlan.value = null
+  },
+  { immediate: true },
+)
 
 onMounted(() => {
   loadPlans() // 기존 계획 데이터 로드
@@ -202,9 +229,9 @@ const {
   onClickBaseline,
   onClickWorkPlan,
 } = useWorkPlanGantt({
-  baselinePlans,
-  monthlyPlans,
-  annualPlans,
+  baselinePlans: scopedBaselinePlans,
+  monthlyPlans: scopedMonthlyPlans,
+  annualPlans: scopedAnnualPlans,
   filterTrade,
   filterStatus,
   viewMode,
@@ -241,6 +268,7 @@ const {
         </div>
 
         <button
+          v-if="canManageSitePlans"
           type="button"
           class="inline-flex items-center gap-1.5 rounded-lg border border-forena-200 bg-white px-3 py-1.5 text-xs font-semibold text-forena-700 hover:bg-forena-50"
           @click="isUploadPopupOpen = true"
@@ -291,10 +319,11 @@ const {
         <span class="text-[11px] font-bold text-forena-400">공종</span>
         <select
           v-model="filterTrade"
+          :disabled="isTradeScope"
           class="rounded-md border border-forena-200 bg-white px-2.5 py-1.5 text-xs text-forena-800 outline-none focus:border-flare-400"
         >
           <option value="">전체</option>
-          <option v-for="t in trades" :key="t">{{ t }}</option>
+          <option v-for="t in tradeFilterOptions" :key="t">{{ t }}</option>
         </select>
       </div>
 

--- a/src/views/system/LoginView.vue
+++ b/src/views/system/LoginView.vue
@@ -186,12 +186,13 @@ const pageBackground = computed(
     `url(${bgImage})`,
 )
 
+const postLoginPath = () => (authStore.initialUploadRequired ? '/site/upload' : '/site/dashboard')
+
 watch(
   () => authStore.isAuthenticated,
   (v) => {
     if (v && !authStore.stayOnLogin) {
-      const path = authStore.isUpload ? '/site/dashboard' : '/site/upload'
-      router.push({ path, query: { site: selectedSiteId.value } })
+      router.push({ path: postLoginPath(), query: selectedSiteQuery() })
     }
   },
   { immediate: true },
@@ -204,7 +205,11 @@ const clearAccount = () => {
   successMessage.value = ''
 }
 
-const selectedSiteQuery = () => ({ site: selectedSiteId.value })
+function selectedSiteQuery() {
+  const query = { site: selectedSiteId.value }
+  if (authStore.projectId) query.projectId = String(authStore.projectId)
+  return query
+}
 
 const goToSiteDashboard = () => {
   router.push({ path: '/site/dashboard', query: selectedSiteQuery() })
@@ -227,8 +232,7 @@ const handleLogin = async () => {
       loginId: loginIdInput,
     })
     if (!authStore.stayOnLogin) {
-      const path = authStore.isUpload ? '/site/dashboard' : '/site/upload'
-      router.push({ path, query: { site: selectedSiteId.value } })
+      router.push({ path: postLoginPath(), query: selectedSiteQuery() })
     } else {
       successMessage.value = '로그인되었습니다. 현재 화면을 유지합니다.'
     }
@@ -240,8 +244,7 @@ const handleLogin = async () => {
   if (authStore.loginDemo(loginIdInput, passwordInput)) {
     errorMessage.value = ''
     if (!authStore.stayOnLogin) {
-      const path = authStore.isUpload ? '/site/dashboard' : '/site/upload'
-      router.push({ path, query: { site: selectedSiteId.value } })
+      router.push({ path: postLoginPath(), query: selectedSiteQuery() })
     } else {
       successMessage.value = 'viewer 데모(본사)로 로그인되었습니다. 현재 화면을 유지합니다.'
     }


### PR DESCRIPTION
## 작업 내용

- 로그인 사용자 권한에 따라 프론트 화면의 현장/공종 데이터 조회 범위를 분리했습니다.
- 현장 총 책임자는 담당 현장의 전체 데이터를 볼 수 있도록 처리했습니다.
- 공종별 담당자는 본인 공종에 해당하는 데이터만 보이도록 필터링했습니다.
- 전체 공정표 화면은 예외적으로 모든 공종이 포함된 간트차트를 조회하도록 수정했습니다.
- 현재 로그인 사용자의 `projectId`, `trade`, `role` 정보를 기준으로 API 요청 파라미터와 화면 필터를 정리했습니다.
- 초기 공정표 업로드 화면에서 시스템 관리자가 등록한 현장 정보를 기본값으로 사용하도록 수정했습니다.
- 공사명 항목을 공사 위치 기준으로 표시하도록 문구와 데이터 매핑을 조정했습니다.
- 공정계획 간트차트의 반응형 표시를 개선했습니다.

## 주요 변경 사항

- `authScope` 유틸 추가
- 로그인/권한 상태 기반 라우팅 및 사이드바 표시 개선
- 전체 공정표 API 호출 시 `includeAllTrades` 옵션 적용
- 공정계획, 작업지시, 공사일보, 공정분석 화면의 공종별 필터링 적용
- 현장 총 책임자와 공종별 담당자 화면 데이터 분기 처리
- 초기 공정표 업로드 및 프로젝트 기본 정보 표시 로직 수정
- 간트차트 레이아웃 반응형 개선